### PR TITLE
Add claude-respond composite action + test workflow

### DIFF
--- a/.github/workflows/test-claude-respond.yml
+++ b/.github/workflows/test-claude-respond.yml
@@ -1,0 +1,32 @@
+name: "Test: Claude Respond"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude-respond:
+    # Only run on @claude mentions or issue assignment
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.action == 'opened' && contains(github.event.issue.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.action == 'assigned')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Claude Respond
+        uses: ./claude-respond
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+          timeout_minutes: "10"
+          max_turns: "5"

--- a/claude-respond/action.yml
+++ b/claude-respond/action.yml
@@ -1,0 +1,204 @@
+name: "Claude Respond"
+description: "Interactive Claude assistant triggered by @claude mentions in issues and PRs. Wraps anthropics/claude-code-action with simplified auth and input handling."
+branding:
+  icon: "message-circle"
+  color: "orange"
+
+inputs:
+  # Auth — at least one Claude auth method required
+  claude_code_oauth_token:
+    description: "Claude Code OAuth token (from `claude setup-token`). Preferred — uses subscription billing."
+    required: false
+  anthropic_api_key:
+    description: "Anthropic API key. Fallback — uses per-token billing."
+    required: false
+
+  # GitHub auth — optional GitHub App, falls back to github.token
+  github_token:
+    description: "GitHub token. If not provided and no App credentials, falls back to the workflow's GITHUB_TOKEN."
+    required: false
+  app_id:
+    description: "GitHub App ID for generating an installation token with elevated permissions."
+    required: false
+  app_private_key:
+    description: "GitHub App private key (PEM format) for generating an installation token."
+    required: false
+
+  # Trigger configuration
+  trigger_phrase:
+    description: "Phrase that triggers Claude in comments."
+    required: false
+    default: "@claude"
+  assignee_trigger:
+    description: "Username that triggers Claude when assigned to an issue."
+    required: false
+  label_trigger:
+    description: "Label that triggers Claude when applied to an issue/PR."
+    required: false
+
+  # Claude configuration
+  model:
+    description: "Claude model to use (e.g., claude-sonnet-4-20250514). Passed via --model flag."
+    required: false
+  max_turns:
+    description: "Maximum agentic turns per invocation. Passed via --max-turns flag."
+    required: false
+  timeout_minutes:
+    description: "Timeout in minutes for the Claude Code process. Passed via --timeout flag."
+    required: false
+    default: "60"
+  allowed_tools:
+    description: "Comma-separated list of allowed tools. Passed via --allowedTools flag."
+    required: false
+  disallowed_tools:
+    description: "Comma-separated list of disallowed tools. Passed via --disallowedTools flag."
+    required: false
+
+  # Advanced configuration
+  claude_args:
+    description: "Additional arguments passed directly to Claude CLI. Multiline supported."
+    required: false
+  additional_permissions:
+    description: "Additional GitHub permissions to request (e.g., 'actions: read')."
+    required: false
+  settings:
+    description: "Claude Code settings as JSON string or path to settings JSON file."
+    required: false
+  append_system_prompt:
+    description: "Additional instructions appended to the prompt sent to Claude."
+    required: false
+
+outputs:
+  execution_file:
+    description: "Path to the Claude Code execution output file"
+    value: ${{ steps.claude.outputs.execution_file }}
+  branch_name:
+    description: "The branch created by Claude Code for this execution"
+    value: ${{ steps.claude.outputs.branch_name }}
+
+runs:
+  using: "composite"
+  steps:
+    # Step 1: Generate GitHub App token if App credentials provided
+    - name: Generate GitHub App Token
+      id: app-token
+      if: inputs.app_id != '' && inputs.app_private_key != ''
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.app_id }}
+        private-key: ${{ inputs.app_private_key }}
+
+    # Step 2: Determine effective GitHub token
+    - name: Resolve GitHub Token
+      id: resolve-token
+      shell: bash
+      run: |
+        if [ -n "$APP_TOKEN" ]; then
+          echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+          echo "::notice::Using GitHub App token for authentication"
+        elif [ -n "$EXPLICIT_TOKEN" ]; then
+          echo "token=$EXPLICIT_TOKEN" >> "$GITHUB_OUTPUT"
+          echo "::notice::Using explicitly provided github_token"
+        else
+          echo "token=" >> "$GITHUB_OUTPUT"
+          echo "::notice::No explicit GitHub token — upstream action will use default GITHUB_TOKEN"
+        fi
+      env:
+        APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        EXPLICIT_TOKEN: ${{ inputs.github_token }}
+
+    # Step 3: Validate Claude auth
+    - name: Validate Claude Authentication
+      shell: bash
+      run: |
+        if [ -z "$OAUTH_TOKEN" ] && [ -z "$API_KEY" ]; then
+          echo "::error::No Claude authentication provided. Set either 'claude_code_oauth_token' (recommended) or 'anthropic_api_key'."
+          exit 1
+        fi
+
+        if [ -n "$OAUTH_TOKEN" ]; then
+          echo "::notice::Using Claude Code OAuth token (subscription billing)"
+        else
+          echo "::notice::Using Anthropic API key (per-token billing)"
+        fi
+      env:
+        OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
+        API_KEY: ${{ inputs.anthropic_api_key }}
+
+    # Step 4: Build claude_args from structured inputs
+    - name: Build Claude Args
+      id: build-args
+      shell: bash
+      run: |
+        ARGS=""
+
+        if [ -n "$MODEL" ]; then
+          ARGS="$ARGS --model $MODEL"
+        fi
+
+        if [ -n "$MAX_TURNS" ]; then
+          ARGS="$ARGS --max-turns $MAX_TURNS"
+        fi
+
+        if [ -n "$TIMEOUT_MINUTES" ]; then
+          # Convert minutes to seconds for --timeout flag
+          TIMEOUT_SECS=$((TIMEOUT_MINUTES * 60))
+          ARGS="$ARGS --timeout $TIMEOUT_SECS"
+        fi
+
+        if [ -n "$ALLOWED_TOOLS" ]; then
+          ARGS="$ARGS --allowedTools $ALLOWED_TOOLS"
+        fi
+
+        if [ -n "$DISALLOWED_TOOLS" ]; then
+          ARGS="$ARGS --disallowedTools $DISALLOWED_TOOLS"
+        fi
+
+        # Append any additional raw claude_args
+        if [ -n "$EXTRA_ARGS" ]; then
+          ARGS="$ARGS $EXTRA_ARGS"
+        fi
+
+        echo "args<<EOF" >> "$GITHUB_OUTPUT"
+        echo "$ARGS" >> "$GITHUB_OUTPUT"
+        echo "EOF" >> "$GITHUB_OUTPUT"
+      env:
+        MODEL: ${{ inputs.model }}
+        MAX_TURNS: ${{ inputs.max_turns }}
+        TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
+        ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
+        DISALLOWED_TOOLS: ${{ inputs.disallowed_tools }}
+        EXTRA_ARGS: ${{ inputs.claude_args }}
+
+    # Step 5: Build prompt with optional system prompt append
+    - name: Build Prompt
+      id: build-prompt
+      shell: bash
+      run: |
+        PROMPT=""
+        if [ -n "$APPEND_SYSTEM_PROMPT" ]; then
+          PROMPT="$APPEND_SYSTEM_PROMPT"
+        fi
+
+        echo "prompt<<EOF" >> "$GITHUB_OUTPUT"
+        echo "$PROMPT" >> "$GITHUB_OUTPUT"
+        echo "EOF" >> "$GITHUB_OUTPUT"
+      env:
+        APPEND_SYSTEM_PROMPT: ${{ inputs.append_system_prompt }}
+
+    # Step 6: Invoke upstream claude-code-action
+    - name: Run Claude Code
+      id: claude
+      uses: anthropics/claude-code-action@v1
+      with:
+        trigger_phrase: ${{ inputs.trigger_phrase }}
+        assignee_trigger: ${{ inputs.assignee_trigger }}
+        label_trigger: ${{ inputs.label_trigger }}
+        claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
+        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        github_token: ${{ steps.resolve-token.outputs.token }}
+        prompt: ${{ steps.build-prompt.outputs.prompt }}
+        claude_args: ${{ steps.build-args.outputs.args }}
+        additional_permissions: ${{ inputs.additional_permissions }}
+        settings: ${{ inputs.settings }}
+        timeout_minutes: ${{ inputs.timeout_minutes }}


### PR DESCRIPTION
## Summary

- Implements `claude-respond/action.yml` composite action wrapping `anthropics/claude-code-action@v1`
- Adds `.github/workflows/test-claude-respond.yml` for live testing
- Auth detection (OAuth vs API key), optional GitHub App token generation
- Structured input assembly (model, max_turns, timeout, tools → claude_args)

## Test plan

- [ ] Merge to main (required — issue_comment events only trigger on default branch)
- [ ] Create test issue with `@claude hello` comment
- [ ] Verify Claude responds

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)