### PR TITLE
Pin action references to full-length commit SHAs

### DIFF
--- a/.github/workflows/test-claude-respond.yml
+++ b/.github/workflows/test-claude-respond.yml
@@ -22,7 +22,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run Claude Respond
         uses: ./claude-respond

--- a/claude-respond/action.yml
+++ b/claude-respond/action.yml
@@ -83,7 +83,7 @@ runs:
     - name: Generate GitHub App Token
       id: app-token
       if: inputs.app_id != '' && inputs.app_private_key != ''
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
       with:
         app-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.app_private_key }}
@@ -189,7 +189,7 @@ runs:
     # Step 6: Invoke upstream claude-code-action
     - name: Run Claude Code
       id: claude
-      uses: anthropics/claude-code-action@v1
+      uses: anthropics/claude-code-action@e763fe78de2db7389e04818a00b5ff8ba13d1360 # v1
       with:
         trigger_phrase: ${{ inputs.trigger_phrase }}
         assignee_trigger: ${{ inputs.assignee_trigger }}


### PR DESCRIPTION
## Summary

- Pin all action `uses:` references to full-length commit SHAs (required by repo policy)
- Fixes workflow failure from #9 test

## Test plan

- [ ] Merge to main
- [ ] Re-trigger test issue #9 with a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)