### PR TITLE
Fix invalid input passthrough and add id-token permission

### DIFF
--- a/.github/workflows/test-claude-respond.yml
+++ b/.github/workflows/test-claude-respond.yml
@@ -21,6 +21,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/claude-respond/action.yml
+++ b/claude-respond/action.yml
@@ -201,4 +201,3 @@ runs:
         claude_args: ${{ steps.build-args.outputs.args }}
         additional_permissions: ${{ inputs.additional_permissions }}
         settings: ${{ inputs.settings }}
-        timeout_minutes: ${{ inputs.timeout_minutes }}


### PR DESCRIPTION
## Summary

- Remove `timeout_minutes` from upstream action `with:` block (not a valid input)
- Add `id-token: write` permission required by upstream action for OIDC auth

Fixes workflow failure from test issue #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)