### PR TITLE
Refactor into composable actions: claude-core + claude-report

### DIFF
--- a/.github/workflows/test-claude-respond.yml
+++ b/.github/workflows/test-claude-respond.yml
@@ -53,4 +53,4 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
           max_turns: "3"
-          append_system_prompt: ${{ inputs.prompt }}
+          prompt: ${{ inputs.prompt }}

--- a/claude-core/action.yml
+++ b/claude-core/action.yml
@@ -1,0 +1,208 @@
+name: "Claude Core"
+description: "Core execution wrapper around anthropics/claude-code-action@v1. Handles auth, arg building, --verbose output, and execution."
+branding:
+  icon: "cpu"
+  color: "blue"
+
+inputs:
+  # Auth — at least one Claude auth method required
+  claude_code_oauth_token:
+    description: "Claude Code OAuth token (from `claude setup-token`). Preferred — uses subscription billing."
+    required: false
+  anthropic_api_key:
+    description: "Anthropic API key. Fallback — uses per-token billing."
+    required: false
+
+  # GitHub auth — optional GitHub App, falls back to github.token
+  github_token:
+    description: "GitHub token. If not provided and no App credentials, falls back to the workflow's GITHUB_TOKEN."
+    required: false
+  app_id:
+    description: "GitHub App ID for generating an installation token with elevated permissions."
+    required: false
+  app_private_key:
+    description: "GitHub App private key (PEM format) for generating an installation token."
+    required: false
+
+  # Trigger configuration
+  trigger_phrase:
+    description: "Phrase that triggers Claude in comments."
+    required: false
+    default: "@claude"
+  assignee_trigger:
+    description: "Username that triggers Claude when assigned to an issue."
+    required: false
+  label_trigger:
+    description: "Label that triggers Claude when applied to an issue/PR."
+    required: false
+
+  # Claude configuration
+  model:
+    description: "Claude model to use (e.g., claude-sonnet-4-20250514). Passed via --model flag."
+    required: false
+  max_turns:
+    description: "Maximum agentic turns per invocation. Passed via --max-turns flag."
+    required: false
+  timeout_minutes:
+    description: "Timeout in minutes for the Claude Code process. Passed via --timeout flag."
+    required: false
+    default: "60"
+  allowed_tools:
+    description: "Comma-separated list of allowed tools. Passed via --allowedTools flag."
+    required: false
+  disallowed_tools:
+    description: "Comma-separated list of disallowed tools. Passed via --disallowedTools flag."
+    required: false
+
+  # Advanced configuration
+  claude_args:
+    description: "Additional arguments passed directly to Claude CLI. Multiline supported."
+    required: false
+  additional_permissions:
+    description: "Additional GitHub permissions to request (e.g., 'actions: read')."
+    required: false
+  settings:
+    description: "Claude Code settings as JSON string or path to settings JSON file."
+    required: false
+  prompt:
+    description: "Text to send to Claude as the prompt. Replaces append_system_prompt."
+    required: false
+  display_report:
+    description: "Show the full Claude Code Report in GitHub Job Summary."
+    required: false
+    default: "true"
+
+outputs:
+  execution_file:
+    description: "Path to the Claude Code execution output file"
+    value: ${{ steps.claude.outputs.execution_file }}
+  branch_name:
+    description: "The branch created by Claude Code for this execution"
+    value: ${{ steps.claude.outputs.branch_name }}
+  session_id:
+    description: "Claude Code session ID for resuming conversations"
+    value: ${{ steps.claude.outputs.session_id }}
+
+runs:
+  using: "composite"
+  steps:
+    # Step 1: Generate GitHub App token if App credentials provided
+    - name: Generate GitHub App Token
+      id: app-token
+      if: inputs.app_id != '' && inputs.app_private_key != ''
+      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+      with:
+        app-id: ${{ inputs.app_id }}
+        private-key: ${{ inputs.app_private_key }}
+
+    # Step 2: Determine effective GitHub token
+    - name: Resolve GitHub Token
+      id: resolve-token
+      shell: bash
+      run: |
+        if [ -n "$APP_TOKEN" ]; then
+          echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+          echo "::notice::Using GitHub App token for authentication"
+        elif [ -n "$EXPLICIT_TOKEN" ]; then
+          echo "token=$EXPLICIT_TOKEN" >> "$GITHUB_OUTPUT"
+          echo "::notice::Using explicitly provided github_token"
+        else
+          echo "token=" >> "$GITHUB_OUTPUT"
+          echo "::notice::No explicit GitHub token — upstream action will use default GITHUB_TOKEN"
+        fi
+      env:
+        APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        EXPLICIT_TOKEN: ${{ inputs.github_token }}
+
+    # Step 3: Validate Claude auth
+    - name: Validate Claude Authentication
+      shell: bash
+      run: |
+        if [ -z "$OAUTH_TOKEN" ] && [ -z "$API_KEY" ]; then
+          echo "::error::No Claude authentication provided. Set either 'claude_code_oauth_token' (recommended) or 'anthropic_api_key'."
+          exit 1
+        fi
+
+        if [ -n "$OAUTH_TOKEN" ]; then
+          echo "::notice::Using Claude Code OAuth token (subscription billing)"
+        else
+          echo "::notice::Using Anthropic API key (per-token billing)"
+        fi
+      env:
+        OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
+        API_KEY: ${{ inputs.anthropic_api_key }}
+
+    # Step 4: Build claude_args from structured inputs (always appends --verbose)
+    - name: Build Claude Args
+      id: build-args
+      shell: bash
+      run: |
+        ARGS=""
+
+        if [ -n "$MODEL" ]; then
+          ARGS="$ARGS --model $MODEL"
+        fi
+
+        if [ -n "$MAX_TURNS" ]; then
+          ARGS="$ARGS --max-turns $MAX_TURNS"
+        fi
+
+        if [ -n "$ALLOWED_TOOLS" ]; then
+          ARGS="$ARGS --allowedTools $ALLOWED_TOOLS"
+        fi
+
+        if [ -n "$DISALLOWED_TOOLS" ]; then
+          ARGS="$ARGS --disallowedTools $DISALLOWED_TOOLS"
+        fi
+
+        # Append any additional raw claude_args
+        if [ -n "$EXTRA_ARGS" ]; then
+          ARGS="$ARGS $EXTRA_ARGS"
+        fi
+
+        # Always append --verbose for full turn-by-turn JSON output
+        ARGS="$ARGS --verbose"
+
+        echo "args<<EOF" >> "$GITHUB_OUTPUT"
+        echo "$ARGS" >> "$GITHUB_OUTPUT"
+        echo "EOF" >> "$GITHUB_OUTPUT"
+      env:
+        MODEL: ${{ inputs.model }}
+        MAX_TURNS: ${{ inputs.max_turns }}
+        ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
+        DISALLOWED_TOOLS: ${{ inputs.disallowed_tools }}
+        EXTRA_ARGS: ${{ inputs.claude_args }}
+
+    # Step 5: Build prompt
+    - name: Build Prompt
+      id: build-prompt
+      shell: bash
+      run: |
+        PROMPT=""
+        if [ -n "$PROMPT_TEXT" ]; then
+          PROMPT="$PROMPT_TEXT"
+        fi
+
+        echo "prompt<<EOF" >> "$GITHUB_OUTPUT"
+        echo "$PROMPT" >> "$GITHUB_OUTPUT"
+        echo "EOF" >> "$GITHUB_OUTPUT"
+      env:
+        PROMPT_TEXT: ${{ inputs.prompt }}
+
+    # Step 6: Invoke upstream claude-code-action
+    - name: Run Claude Code
+      id: claude
+      uses: anthropics/claude-code-action@e763fe78de2db7389e04818a00b5ff8ba13d1360 # v1
+      with:
+        trigger_phrase: ${{ inputs.trigger_phrase }}
+        assignee_trigger: ${{ inputs.assignee_trigger }}
+        label_trigger: ${{ inputs.label_trigger }}
+        claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
+        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        github_token: ${{ steps.resolve-token.outputs.token }}
+        prompt: ${{ steps.build-prompt.outputs.prompt }}
+        claude_args: ${{ steps.build-args.outputs.args }}
+        additional_permissions: ${{ inputs.additional_permissions }}
+        settings: ${{ inputs.settings }}
+        timeout_minutes: ${{ inputs.timeout_minutes }}
+        display_report: ${{ inputs.display_report }}

--- a/claude-report/action.yml
+++ b/claude-report/action.yml
@@ -1,0 +1,118 @@
+name: "Claude Report"
+description: "Generates execution summary table and uploads artifact from Claude Code execution output."
+branding:
+  icon: "bar-chart-2"
+  color: "green"
+
+inputs:
+  execution_file:
+    description: "Path to the Claude Code execution JSON file."
+    required: true
+  session_id:
+    description: "Claude Code session ID to display in the summary."
+    required: false
+    default: ""
+  outcome:
+    description: "Execution outcome — 'success' or 'failure' for status display."
+    required: false
+    default: "success"
+  artifact_name:
+    description: "Override the artifact name."
+    required: false
+    default: "claude-execution-${{ github.run_id }}"
+  retention_days:
+    description: "Artifact retention in days."
+    required: false
+    default: "30"
+
+runs:
+  using: "composite"
+  steps:
+    # Step 1: Generate concise execution summary
+    - name: Claude Execution Summary
+      if: always()
+      shell: bash
+      run: |
+        EXEC_FILE="$INPUT_EXECUTION_FILE"
+        SESSION_ID="$INPUT_SESSION_ID"
+        OUTCOME="$INPUT_OUTCOME"
+
+        # Determine status
+        if [ "$OUTCOME" = "success" ]; then
+          STATUS="✅ Success"
+        else
+          STATUS="❌ Failed"
+        fi
+
+        # If no execution file, write a minimal summary
+        if [ -z "$EXEC_FILE" ] || [ ! -f "$EXEC_FILE" ]; then
+          {
+            echo "## Claude Execution Summary"
+            echo ""
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            echo "| Status | $STATUS |"
+            echo "| Session ID | \`$SESSION_ID\` |"
+            echo ""
+            echo "> No execution file found — detailed metrics unavailable."
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        # Extract result turn metrics
+        RESULT=$(jq -r '.[] | select(.type == "result")' "$EXEC_FILE")
+
+        COST=$(echo "$RESULT" | jq -r '.total_cost_usd // 0')
+        DURATION_MS=$(echo "$RESULT" | jq -r '.duration_ms // 0')
+        NUM_TURNS=$(echo "$RESULT" | jq -r '.num_turns // "?"')
+
+        # Format duration
+        DURATION=$(awk "BEGIN { printf \"%.1fs\", $DURATION_MS / 1000 }")
+
+        # Format cost
+        COST_FMT=$(awk "BEGIN { printf \"\\$%.4f\", $COST }")
+
+        # Sum token usage across all turns
+        INPUT_TOKENS=$(jq '[.[] | .usage.input_tokens // 0] | add' "$EXEC_FILE")
+        OUTPUT_TOKENS=$(jq '[.[] | .usage.output_tokens // 0] | add' "$EXEC_FILE")
+        CACHE_READ=$(jq '[.[] | .usage.cache_read_input_tokens // 0] | add' "$EXEC_FILE")
+        CACHE_CREATE=$(jq '[.[] | .usage.cache_creation_input_tokens // 0] | add' "$EXEC_FILE")
+
+        # Format numbers with commas
+        fmt() { printf "%'d" "$1" 2>/dev/null || echo "$1"; }
+
+        # Detect model from the first assistant turn
+        MODEL=$(jq -r '[.[] | select(.type == "assistant") | .model // empty][0] // "unknown"' "$EXEC_FILE")
+
+        # Write summary (prepended before the verbose report)
+        {
+          echo "## Claude Execution Summary"
+          echo ""
+          echo "| Metric | Value |"
+          echo "|--------|-------|"
+          echo "| Status | $STATUS |"
+          echo "| Duration | $DURATION |"
+          echo "| Turns | $NUM_TURNS |"
+          echo "| Cost | $COST_FMT |"
+          echo "| Input tokens | $(fmt "${INPUT_TOKENS:-0}") |"
+          echo "| Output tokens | $(fmt "${OUTPUT_TOKENS:-0}") |"
+          echo "| Cache read | $(fmt "${CACHE_READ:-0}") |"
+          echo "| Cache creation | $(fmt "${CACHE_CREATE:-0}") |"
+          echo "| Model | $MODEL |"
+          echo "| Session ID | \`$SESSION_ID\` |"
+          echo ""
+        } >> "$GITHUB_STEP_SUMMARY"
+      env:
+        INPUT_EXECUTION_FILE: ${{ inputs.execution_file }}
+        INPUT_SESSION_ID: ${{ inputs.session_id }}
+        INPUT_OUTCOME: ${{ inputs.outcome }}
+
+    # Step 2: Upload execution log as artifact
+    - name: Upload Execution Log
+      if: always() && inputs.execution_file != ''
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.execution_file }}
+        retention-days: ${{ inputs.retention_days }}

--- a/claude-respond/action.yml
+++ b/claude-respond/action.yml
@@ -1,5 +1,5 @@
 name: "Claude Respond"
-description: "Interactive Claude assistant triggered by @claude mentions in issues and PRs. Wraps anthropics/claude-code-action with simplified auth and input handling."
+description: "Interactive Claude assistant triggered by @claude mentions in issues and PRs. Composes claude-core and claude-report for auth, execution, and reporting."
 branding:
   icon: "message-circle"
   color: "orange"
@@ -64,133 +64,57 @@ inputs:
   settings:
     description: "Claude Code settings as JSON string or path to settings JSON file."
     required: false
-  append_system_prompt:
-    description: "Additional instructions appended to the prompt sent to Claude."
+  prompt:
+    description: "Text to send to Claude as the prompt."
     required: false
+  display_report:
+    description: "Show the full Claude Code Report in GitHub Job Summary."
+    required: false
+    default: "true"
 
 outputs:
   execution_file:
     description: "Path to the Claude Code execution output file"
-    value: ${{ steps.claude.outputs.execution_file }}
+    value: ${{ steps.core.outputs.execution_file }}
   branch_name:
     description: "The branch created by Claude Code for this execution"
-    value: ${{ steps.claude.outputs.branch_name }}
+    value: ${{ steps.core.outputs.branch_name }}
+  session_id:
+    description: "Claude Code session ID for resuming conversations"
+    value: ${{ steps.core.outputs.session_id }}
 
 runs:
   using: "composite"
   steps:
-    # Step 1: Generate GitHub App token if App credentials provided
-    - name: Generate GitHub App Token
-      id: app-token
-      if: inputs.app_id != '' && inputs.app_private_key != ''
-      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
+    # Step 1: Run Claude via claude-core
+    - name: Run Claude Core
+      id: core
+      uses: diranged/claude-code-agentic-workflows/claude-core@issue-2/fix-args
       with:
-        app-id: ${{ inputs.app_id }}
-        private-key: ${{ inputs.app_private_key }}
-
-    # Step 2: Determine effective GitHub token
-    - name: Resolve GitHub Token
-      id: resolve-token
-      shell: bash
-      run: |
-        if [ -n "$APP_TOKEN" ]; then
-          echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
-          echo "::notice::Using GitHub App token for authentication"
-        elif [ -n "$EXPLICIT_TOKEN" ]; then
-          echo "token=$EXPLICIT_TOKEN" >> "$GITHUB_OUTPUT"
-          echo "::notice::Using explicitly provided github_token"
-        else
-          echo "token=" >> "$GITHUB_OUTPUT"
-          echo "::notice::No explicit GitHub token — upstream action will use default GITHUB_TOKEN"
-        fi
-      env:
-        APP_TOKEN: ${{ steps.app-token.outputs.token }}
-        EXPLICIT_TOKEN: ${{ inputs.github_token }}
-
-    # Step 3: Validate Claude auth
-    - name: Validate Claude Authentication
-      shell: bash
-      run: |
-        if [ -z "$OAUTH_TOKEN" ] && [ -z "$API_KEY" ]; then
-          echo "::error::No Claude authentication provided. Set either 'claude_code_oauth_token' (recommended) or 'anthropic_api_key'."
-          exit 1
-        fi
-
-        if [ -n "$OAUTH_TOKEN" ]; then
-          echo "::notice::Using Claude Code OAuth token (subscription billing)"
-        else
-          echo "::notice::Using Anthropic API key (per-token billing)"
-        fi
-      env:
-        OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
-        API_KEY: ${{ inputs.anthropic_api_key }}
-
-    # Step 4: Build claude_args from structured inputs
-    - name: Build Claude Args
-      id: build-args
-      shell: bash
-      run: |
-        ARGS=""
-
-        if [ -n "$MODEL" ]; then
-          ARGS="$ARGS --model $MODEL"
-        fi
-
-        if [ -n "$MAX_TURNS" ]; then
-          ARGS="$ARGS --max-turns $MAX_TURNS"
-        fi
-
-        if [ -n "$ALLOWED_TOOLS" ]; then
-          ARGS="$ARGS --allowedTools $ALLOWED_TOOLS"
-        fi
-
-        if [ -n "$DISALLOWED_TOOLS" ]; then
-          ARGS="$ARGS --disallowedTools $DISALLOWED_TOOLS"
-        fi
-
-        # Append any additional raw claude_args
-        if [ -n "$EXTRA_ARGS" ]; then
-          ARGS="$ARGS $EXTRA_ARGS"
-        fi
-
-        echo "args<<EOF" >> "$GITHUB_OUTPUT"
-        echo "$ARGS" >> "$GITHUB_OUTPUT"
-        echo "EOF" >> "$GITHUB_OUTPUT"
-      env:
-        MODEL: ${{ inputs.model }}
-        MAX_TURNS: ${{ inputs.max_turns }}
-        ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
-        DISALLOWED_TOOLS: ${{ inputs.disallowed_tools }}
-        EXTRA_ARGS: ${{ inputs.claude_args }}
-
-    # Step 5: Build prompt with optional system prompt append
-    - name: Build Prompt
-      id: build-prompt
-      shell: bash
-      run: |
-        PROMPT=""
-        if [ -n "$APPEND_SYSTEM_PROMPT" ]; then
-          PROMPT="$APPEND_SYSTEM_PROMPT"
-        fi
-
-        echo "prompt<<EOF" >> "$GITHUB_OUTPUT"
-        echo "$PROMPT" >> "$GITHUB_OUTPUT"
-        echo "EOF" >> "$GITHUB_OUTPUT"
-      env:
-        APPEND_SYSTEM_PROMPT: ${{ inputs.append_system_prompt }}
-
-    # Step 6: Invoke upstream claude-code-action
-    - name: Run Claude Code
-      id: claude
-      uses: anthropics/claude-code-action@e763fe78de2db7389e04818a00b5ff8ba13d1360 # v1
-      with:
+        claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
+        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        github_token: ${{ inputs.github_token }}
+        app_id: ${{ inputs.app_id }}
+        app_private_key: ${{ inputs.app_private_key }}
         trigger_phrase: ${{ inputs.trigger_phrase }}
         assignee_trigger: ${{ inputs.assignee_trigger }}
         label_trigger: ${{ inputs.label_trigger }}
-        claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
-        anthropic_api_key: ${{ inputs.anthropic_api_key }}
-        github_token: ${{ steps.resolve-token.outputs.token }}
-        prompt: ${{ steps.build-prompt.outputs.prompt }}
-        claude_args: ${{ steps.build-args.outputs.args }}
+        model: ${{ inputs.model }}
+        max_turns: ${{ inputs.max_turns }}
+        timeout_minutes: ${{ inputs.timeout_minutes }}
+        allowed_tools: ${{ inputs.allowed_tools }}
+        disallowed_tools: ${{ inputs.disallowed_tools }}
+        claude_args: ${{ inputs.claude_args }}
         additional_permissions: ${{ inputs.additional_permissions }}
         settings: ${{ inputs.settings }}
+        prompt: ${{ inputs.prompt }}
+        display_report: ${{ inputs.display_report }}
+
+    # Step 2: Generate report and upload artifact
+    - name: Generate Report
+      if: always()
+      uses: diranged/claude-code-agentic-workflows/claude-report@issue-2/fix-args
+      with:
+        execution_file: ${{ steps.core.outputs.execution_file }}
+        session_id: ${{ steps.core.outputs.session_id }}
+        outcome: ${{ steps.core.outcome }}


### PR DESCRIPTION
## Summary
- Extract `claude-respond` into three composable layers: `claude-core` (auth, arg building, execution), `claude-report` (summary table + artifact upload), and `claude-respond` (thin composition)
- Always append `--verbose` flag in `claude-core` for full turn-by-turn JSON output
- Rename `append_system_prompt` input to `prompt`

## Test plan
- [x] Triggered workflow_dispatch — composition chain works (core → report)
- [x] Report fallback handles missing execution file gracefully
- [ ] Full end-to-end test after merge (OIDC token requires workflow on default branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)