### PR TITLE
Add issue-triggered Claude workflows with composable prompts

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -1,0 +1,100 @@
+name: "Claude Issue Agent"
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [assigned]
+
+jobs:
+  # Job 1: Determine if we should run and which agent to use
+  detect-intent:
+    runs-on: ubuntu-latest
+    if: >-
+      !github.event.issue.pull_request
+      && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+        || (github.event_name == 'issues' && github.event.action == 'assigned')
+      )
+    outputs:
+      should_run: ${{ steps.detect.outputs.should_run }}
+      agent: ${{ steps.detect.outputs.agent }}
+      issue_number: ${{ steps.detect.outputs.issue_number }}
+    steps:
+      - name: Detect intent
+        id: detect
+        run: |
+          echo "issue_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+
+          BODY="${{ github.event.comment.body || '' }}"
+
+          if [[ "$BODY" == *"@claude implement"* ]]; then
+            echo "agent=agentic-developer" >> "$GITHUB_OUTPUT"
+          else
+            echo "agent=agentic-designer" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+  # Job 2: React to the trigger and create a tracking comment
+  setup:
+    runs-on: ubuntu-latest
+    needs: detect-intent
+    if: needs.detect-intent.outputs.should_run == 'true'
+    outputs:
+      comment_id: ${{ steps.create-comment.outputs.comment_id }}
+    steps:
+      - name: Add reaction to triggering comment
+        if: github.event_name == 'issue_comment'
+        run: |
+          gh api \
+            --method POST \
+            "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content='rocket'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+
+      - name: Create tracking comment
+        id: create-comment
+        run: |
+          COMMENT_ID=$(gh api \
+            --method POST \
+            "/repos/${{ github.repository }}/issues/${{ needs.detect-intent.outputs.issue_number }}/comments" \
+            -f body="$(cat <<'EOF'
+          <!-- claude-tracking-comment -->
+
+          ## Status: Initializing
+
+          **Run:** [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          Claude is initializing...
+          EOF
+          )" \
+            --jq '.id')
+          echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+
+  # Job 3: Run Claude with composed prompt
+  claude-run:
+    runs-on: diranged-claude-code
+    needs: [detect-intent, setup]
+    if: needs.detect-intent.outputs.should_run == 'true'
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Run Claude
+        uses: ./claude-respond
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+          compose_prompt: "true"
+          agent_name: ${{ needs.detect-intent.outputs.agent }}
+          issue_comment_id: ${{ needs.setup.outputs.comment_id }}

--- a/claude-core/action.yml
+++ b/claude-core/action.yml
@@ -67,6 +67,19 @@ inputs:
   prompt:
     description: "Text to send to Claude as the prompt. Replaces append_system_prompt."
     required: false
+
+  # Compose prompt configuration
+  agent_name:
+    description: "Agent to load from agents/ directory (e.g., 'agentic-designer')"
+    required: false
+  compose_prompt:
+    description: "Compose prompt from instructions/skills/agent (true/false)"
+    required: false
+    default: "false"
+  issue_comment_id:
+    description: "Tracking comment ID for progress updates"
+    required: false
+
   display_report:
     description: "Show the full Claude Code Report in GitHub Job Summary."
     required: false
@@ -132,7 +145,23 @@ runs:
       env:
         PROMPT_TEXT: ${{ inputs.prompt }}
 
-    # Step 6: Invoke upstream claude-code-action
+    # Step 6: Compose prompt from instructions/skills/agent (optional)
+    - name: Compose Prompt
+      id: compose-prompt
+      if: inputs.compose_prompt == 'true'
+      shell: bash
+      run: ${{ github.action_path }}/scripts/compose_prompt.sh
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        WORKSPACE_PATH: ${{ github.workspace }}
+        AGENT_NAME: ${{ inputs.agent_name }}
+        PROMPT_TEXT: ${{ inputs.prompt }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        COMMENT_ID: ${{ inputs.issue_comment_id }}
+        RUN_ID: ${{ github.run_id }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    # Step 7: Invoke upstream claude-code-action
     - name: Run Claude Code
       id: claude
       uses: anthropics/claude-code-action@e763fe78de2db7389e04818a00b5ff8ba13d1360 # v1
@@ -143,7 +172,7 @@ runs:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
         github_token: ${{ steps.resolve-token.outputs.token }}
-        prompt: ${{ steps.build-prompt.outputs.prompt }}
+        prompt: ${{ inputs.compose_prompt == 'true' && steps.compose-prompt.outputs.prompt || steps.build-prompt.outputs.prompt }}
         claude_args: ${{ steps.build-args.outputs.args }}
         additional_permissions: ${{ inputs.additional_permissions }}
         settings: ${{ inputs.settings }}

--- a/claude-core/agents/agentic-designer.md
+++ b/claude-core/agents/agentic-designer.md
@@ -1,0 +1,33 @@
+# Agent: Agentic Designer
+
+You are operating as a **design agent**. Your job is to read the issue, explore the codebase, and produce a detailed design document — but **not** to write any code.
+
+## Workflow
+
+1. **Read the issue** — understand the requirements, constraints, and acceptance criteria.
+2. **Explore the codebase** — identify relevant files, patterns, and architecture. Understand how similar features are implemented.
+3. **Design the solution** — determine which files to create or modify, what the implementation approach should be, and how to test it.
+4. **Post the design** — update the tracking comment with your design document.
+5. **Request review** — set the status to "Needs Input" and ask the issue author to review.
+
+## Design Document Structure
+
+Your design should include:
+
+- **Summary** — one-paragraph overview of the proposed changes.
+- **Files to Create/Modify** — table of files with the action (create/modify) and a brief description of changes.
+- **Implementation Details** — key decisions, algorithms, data structures, or patterns you will use.
+- **Test Plan** — what tests to write and what they should cover.
+- **Open Questions** — anything you need clarified before implementation.
+
+## Footer
+
+End the design with:
+
+> To implement this design, comment: `@claude implement`
+
+## Constraints
+
+- **Read-only.** Do not create branches, modify files, or open pull requests.
+- Do not run any commands that modify the repository state.
+- Your only output is the design document posted to the tracking comment.

--- a/claude-core/agents/agentic-developer.md
+++ b/claude-core/agents/agentic-developer.md
@@ -1,0 +1,23 @@
+# Agent: Agentic Developer
+
+You are operating as an **implementation agent**. Your job is to read an approved design from the issue comments and implement it faithfully.
+
+## Workflow
+
+1. **Read the issue and design** — find the most recent design document in the issue comments (look for the `<!-- claude-tracking-comment -->` marker). Understand the full scope.
+2. **Create a feature branch** — use the naming convention `claude/{issue_number}-{short-description}` (e.g., `claude/42-add-auth-middleware`).
+3. **Implement the changes** — follow the design document. Write clean, well-structured code that matches existing patterns.
+4. **Write tests** — add tests as specified in the design's test plan. Ensure adequate coverage.
+5. **Run tests** — execute the project's test suite. Fix any failures before proceeding.
+6. **Create a pull request** — open a PR with:
+   - A clear title summarizing the change.
+   - `Closes #ISSUE_NUMBER` in the PR body to auto-close the issue on merge.
+   - A summary of what was implemented and any deviations from the design.
+7. **Update tracking comment** — set status to "Completed" with a link to the PR.
+
+## Rules
+
+- Follow the approved design. If you discover the design is incomplete or incorrect, update the tracking comment with status "Needs Input" and explain what needs to change.
+- Do not skip tests. If the project has a test suite, run it before creating the PR.
+- Keep commits focused and well-described.
+- Branch naming: `claude/{issue_number}-{short-description}` — use lowercase, hyphens, no spaces.

--- a/claude-core/instructions/00-base.md
+++ b/claude-core/instructions/00-base.md
@@ -1,0 +1,12 @@
+# Base Instructions
+
+You are Claude, an AI assistant helping with software engineering tasks in a GitHub repository.
+
+## Core Rules
+
+- **Never push directly to main/master.** Always create a feature branch and open a pull request.
+- Be concise and focused — only make changes that are directly requested or clearly necessary.
+- Follow existing code patterns, naming conventions, and project structure.
+- Write tests for new functionality. Run existing tests before opening a PR to avoid regressions.
+- Do not add unnecessary dependencies, comments, or abstractions.
+- When modifying existing files, preserve the surrounding style (indentation, formatting, idioms).

--- a/claude-core/instructions/10-github.md
+++ b/claude-core/instructions/10-github.md
@@ -1,0 +1,14 @@
+# GitHub Environment
+
+## Available Tools
+
+- `GITHUB_TOKEN` is set in the environment with permissions for issues, pull requests, and contents.
+- The `gh` CLI is available and authenticated. Use it for all GitHub API interactions.
+- The repository is checked out at the workspace root.
+
+## Comment Management
+
+- A **tracking comment** has been created on the issue for you to post progress updates.
+- **Never create new top-level comments** on the issue — always update the existing tracking comment.
+- The tracking comment ID is provided in the runtime context below.
+- Use `gh api` with PATCH to update the comment body.

--- a/claude-core/scripts/compose_prompt.sh
+++ b/claude-core/scripts/compose_prompt.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Compose a full prompt from instructions, skills, agent definition, and runtime context.
+#
+# Reads markdown files from:
+#   1. $ACTION_PATH/instructions/*.md  (sorted)
+#   2. $WORKSPACE_PATH/.github/claude-instructions/*.md  (user overrides, sorted)
+#   3. $ACTION_PATH/skills/*.md  (sorted)
+#   4. $WORKSPACE_PATH/.github/claude-skills/*.md  (user overrides, sorted)
+#   5. Agent file: user override or built-in
+#   6. Runtime context (run ID, issue number, etc.)
+#   7. PROMPT_TEXT as "Task Context"
+#
+# Required env: ACTION_PATH, WORKSPACE_PATH, AGENT_NAME
+# Optional env: PROMPT_TEXT, ISSUE_NUMBER, COMMENT_ID, RUN_ID, RUN_URL
+set -euo pipefail
+
+PROMPT=""
+
+append_section() {
+  local content="$1"
+  if [ -n "$content" ]; then
+    PROMPT="${PROMPT}${content}"$'\n\n'
+  fi
+}
+
+# Load all .md files from a directory (sorted), if it exists
+load_dir() {
+  local dir="$1"
+  if [ -d "$dir" ]; then
+    for f in "$dir"/*.md; do
+      [ -f "$f" ] || continue
+      append_section "$(cat "$f")"
+    done
+  fi
+}
+
+# --- 1. Base instructions ---
+load_dir "${ACTION_PATH}/instructions"
+
+# --- 2. User instruction overrides ---
+load_dir "${WORKSPACE_PATH}/.github/claude-instructions"
+
+# --- 3. Skills ---
+load_dir "${ACTION_PATH}/skills"
+
+# --- 4. User skill overrides ---
+load_dir "${WORKSPACE_PATH}/.github/claude-skills"
+
+# --- 5. Agent definition ---
+if [ -n "${AGENT_NAME:-}" ]; then
+  AGENT_FILE=""
+  USER_AGENT="${WORKSPACE_PATH}/.github/claude-agents/${AGENT_NAME}.md"
+  BUILTIN_AGENT="${ACTION_PATH}/agents/${AGENT_NAME}.md"
+
+  if [ -f "$USER_AGENT" ]; then
+    AGENT_FILE="$USER_AGENT"
+  elif [ -f "$BUILTIN_AGENT" ]; then
+    AGENT_FILE="$BUILTIN_AGENT"
+  else
+    echo "::error::Agent '${AGENT_NAME}' not found in ${BUILTIN_AGENT} or ${USER_AGENT}"
+    exit 1
+  fi
+
+  append_section "$(cat "$AGENT_FILE")"
+fi
+
+# --- 6. Runtime context ---
+CONTEXT="## Runtime Context"$'\n'
+if [ -n "${RUN_ID:-}" ]; then
+  CONTEXT="${CONTEXT}- Run ID: ${RUN_ID}"$'\n'
+fi
+if [ -n "${RUN_URL:-}" ]; then
+  CONTEXT="${CONTEXT}- Run URL: ${RUN_URL}"$'\n'
+fi
+if [ -n "${ISSUE_NUMBER:-}" ]; then
+  CONTEXT="${CONTEXT}- Issue Number: ${ISSUE_NUMBER}"$'\n'
+fi
+if [ -n "${COMMENT_ID:-}" ]; then
+  CONTEXT="${CONTEXT}- Tracking Comment ID: ${COMMENT_ID}"$'\n'
+fi
+append_section "$CONTEXT"
+
+# --- 7. User prompt ---
+if [ -n "${PROMPT_TEXT:-}" ]; then
+  append_section "## Task Context
+${PROMPT_TEXT}"
+fi
+
+echo "prompt<<COMPOSED_EOF" >> "$GITHUB_OUTPUT"
+echo "$PROMPT" >> "$GITHUB_OUTPUT"
+echo "COMPOSED_EOF" >> "$GITHUB_OUTPUT"

--- a/claude-core/skills/github-issue-progress.md
+++ b/claude-core/skills/github-issue-progress.md
@@ -1,0 +1,47 @@
+# Skill: GitHub Issue Progress Tracking
+
+## Updating the Tracking Comment
+
+Use this command to update the tracking comment on the issue:
+
+```bash
+gh api \
+  --method PATCH \
+  "/repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+  -f body="$(cat <<'COMMENT_EOF'
+<!-- claude-tracking-comment -->
+
+## Status: <STATUS>
+
+**Run:** [View workflow run](<RUN_URL>)
+
+### Progress
+
+- [x] Completed step
+- [ ] Pending step
+
+### Details
+
+<details>
+<summary>Click to expand</summary>
+
+Your detailed content here.
+
+</details>
+COMMENT_EOF
+)"
+```
+
+Replace `<STATUS>` with one of:
+- **In Progress** — actively working
+- **Needs Input** — blocked, waiting for human feedback
+- **Completed** — finished successfully
+- **Failed** — encountered an unrecoverable error
+
+## Rules
+
+1. Update the tracking comment at meaningful milestones (starting work, design posted, PR created, blocked).
+2. Always preserve the `<!-- claude-tracking-comment -->` HTML marker as the first line.
+3. Include the workflow run link so reviewers can inspect logs.
+4. When blocked or needing clarification, set status to **Needs Input** and clearly describe what you need.
+5. Keep the comment body concise — use `<details>` blocks for verbose content.

--- a/claude-core/tests/helpers.py
+++ b/claude-core/tests/helpers.py
@@ -19,6 +19,13 @@ _CLEARED_VARS = [
     "DISALLOWED_TOOLS",
     "EXTRA_ARGS",
     "PROMPT_TEXT",
+    "ACTION_PATH",
+    "WORKSPACE_PATH",
+    "AGENT_NAME",
+    "ISSUE_NUMBER",
+    "COMMENT_ID",
+    "RUN_ID",
+    "RUN_URL",
     "GITHUB_OUTPUT",
 ]
 

--- a/claude-core/tests/test_action_yml.py
+++ b/claude-core/tests/test_action_yml.py
@@ -40,6 +40,9 @@ class TestActionYml(unittest.TestCase):
             "additional_permissions",
             "settings",
             "prompt",
+            "agent_name",
+            "compose_prompt",
+            "issue_comment_id",
             "display_report",
         ]
         for inp in expected:
@@ -54,6 +57,7 @@ class TestActionYml(unittest.TestCase):
         inputs = self.action["inputs"]
         self.assertEqual(inputs["trigger_phrase"]["default"], "@claude")
         self.assertEqual(inputs["timeout_minutes"]["default"], "60")
+        self.assertEqual(inputs["compose_prompt"]["default"], "false")
         self.assertEqual(inputs["display_report"]["default"], "true")
 
     def test_all_steps_use_bash_shell(self):
@@ -104,8 +108,8 @@ class TestActionYml(unittest.TestCase):
                 )
 
     def test_step_count(self):
-        """Should have 6 steps: app-token, resolve-token, validate-auth, build-args, build-prompt, claude."""
-        self.assertEqual(len(self.action["runs"]["steps"]), 6)
+        """Should have 7 steps: app-token, resolve-token, validate-auth, build-args, build-prompt, compose-prompt, claude."""
+        self.assertEqual(len(self.action["runs"]["steps"]), 7)
 
 
 if __name__ == "__main__":

--- a/claude-core/tests/test_compose_prompt.py
+++ b/claude-core/tests/test_compose_prompt.py
@@ -1,0 +1,200 @@
+"""Tests for claude-core/scripts/compose_prompt.sh."""
+
+import os
+import tempfile
+import unittest
+
+from helpers import parse_github_output, run_script
+
+# Paths to built-in content directories
+CORE_DIR = os.path.join(os.path.dirname(__file__), "..")
+INSTRUCTIONS_DIR = os.path.join(CORE_DIR, "instructions")
+SKILLS_DIR = os.path.join(CORE_DIR, "skills")
+AGENTS_DIR = os.path.join(CORE_DIR, "agents")
+
+
+class TestComposePrompt(unittest.TestCase):
+    """Tests for compose_prompt.sh."""
+
+    def _run(self, env_overrides=None, workspace=None):
+        """Run compose_prompt.sh with default env vars, returning outputs dict."""
+        if workspace is None:
+            workspace = tempfile.mkdtemp()
+
+        env = {
+            "ACTION_PATH": CORE_DIR,
+            "WORKSPACE_PATH": workspace,
+            "AGENT_NAME": "",
+            "PROMPT_TEXT": "",
+            "ISSUE_NUMBER": "",
+            "COMMENT_ID": "",
+            "RUN_ID": "",
+            "RUN_URL": "",
+        }
+        if env_overrides:
+            env.update(env_overrides)
+
+        rc, stdout, stderr, outputs = run_script("compose_prompt.sh", env)
+        return rc, stdout, stderr, outputs
+
+    def test_loads_instructions_sorted(self):
+        """Instructions from ACTION_PATH/instructions/ should be included in sorted order."""
+        rc, _, _, outputs = self._run()
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        # 00-base.md content should appear before 10-github.md content
+        base_pos = prompt.find("Base Instructions")
+        github_pos = prompt.find("GitHub Environment")
+        self.assertGreater(base_pos, -1, "Base instructions not found in prompt")
+        self.assertGreater(github_pos, -1, "GitHub instructions not found in prompt")
+        self.assertLess(base_pos, github_pos, "Instructions not in sorted order")
+
+    def test_loads_skills(self):
+        """Skills from ACTION_PATH/skills/ should be included."""
+        rc, _, _, outputs = self._run()
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertIn("GitHub Issue Progress", prompt)
+
+    def test_loads_agent_by_name(self):
+        """Agent definition should be loaded when AGENT_NAME is set."""
+        rc, _, _, outputs = self._run({"AGENT_NAME": "agentic-designer"})
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertIn("Agentic Designer", prompt)
+
+    def test_loads_developer_agent(self):
+        """agentic-developer agent should load correctly."""
+        rc, _, _, outputs = self._run({"AGENT_NAME": "agentic-developer"})
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertIn("Agentic Developer", prompt)
+
+    def test_error_when_agent_not_found(self):
+        """Should fail when agent name doesn't match any file."""
+        rc, stdout, stderr, _ = self._run({"AGENT_NAME": "nonexistent-agent"})
+        self.assertNotEqual(rc, 0)
+        combined = stdout + stderr
+        self.assertIn("nonexistent-agent", combined)
+
+    def test_runtime_context_injection(self):
+        """Runtime context vars should appear in the composed prompt."""
+        rc, _, _, outputs = self._run({
+            "ISSUE_NUMBER": "42",
+            "COMMENT_ID": "12345",
+            "RUN_ID": "99999",
+            "RUN_URL": "https://github.com/test/repo/actions/runs/99999",
+        })
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertIn("Issue Number: 42", prompt)
+        self.assertIn("Tracking Comment ID: 12345", prompt)
+        self.assertIn("Run ID: 99999", prompt)
+        self.assertIn("https://github.com/test/repo/actions/runs/99999", prompt)
+
+    def test_runtime_context_omits_empty_vars(self):
+        """Runtime context should not include lines for empty vars."""
+        rc, _, _, outputs = self._run()
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertNotIn("Issue Number:", prompt)
+        self.assertNotIn("Tracking Comment ID:", prompt)
+
+    def test_prompt_text_appended_as_task_context(self):
+        """PROMPT_TEXT should appear under '## Task Context'."""
+        rc, _, _, outputs = self._run({"PROMPT_TEXT": "Please fix the login bug"})
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertIn("## Task Context", prompt)
+        self.assertIn("Please fix the login bug", prompt)
+
+    def test_no_task_context_when_prompt_empty(self):
+        """No Task Context section when PROMPT_TEXT is empty."""
+        rc, _, _, outputs = self._run()
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertNotIn("## Task Context", prompt)
+
+    def test_user_instruction_overrides(self):
+        """User instruction overrides from WORKSPACE_PATH/.github/claude-instructions/ should be included."""
+        workspace = tempfile.mkdtemp()
+        override_dir = os.path.join(workspace, ".github", "claude-instructions")
+        os.makedirs(override_dir)
+        with open(os.path.join(override_dir, "99-custom.md"), "w") as f:
+            f.write("# Custom User Instruction\n\nAlways use TypeScript.\n")
+
+        rc, _, _, outputs = self._run(workspace=workspace)
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertIn("Custom User Instruction", prompt)
+        self.assertIn("Always use TypeScript", prompt)
+
+    def test_user_skill_overrides(self):
+        """User skill overrides from WORKSPACE_PATH/.github/claude-skills/ should be included."""
+        workspace = tempfile.mkdtemp()
+        override_dir = os.path.join(workspace, ".github", "claude-skills")
+        os.makedirs(override_dir)
+        with open(os.path.join(override_dir, "custom-skill.md"), "w") as f:
+            f.write("# Skill: Custom Deployment\n\nDeploy using kubectl.\n")
+
+        rc, _, _, outputs = self._run(workspace=workspace)
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertIn("Custom Deployment", prompt)
+
+    def test_user_agent_override(self):
+        """User agent override should take priority over built-in agent."""
+        workspace = tempfile.mkdtemp()
+        override_dir = os.path.join(workspace, ".github", "claude-agents")
+        os.makedirs(override_dir)
+        with open(os.path.join(override_dir, "agentic-designer.md"), "w") as f:
+            f.write("# Agent: Custom Designer Override\n\nCustom behavior.\n")
+
+        rc, _, _, outputs = self._run({
+            "AGENT_NAME": "agentic-designer",
+        }, workspace=workspace)
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertIn("Custom Designer Override", prompt)
+        # Should NOT contain the built-in designer content
+        self.assertNotIn("read-only", prompt.lower().split("custom designer override")[0])
+
+    def test_no_agent_when_name_empty(self):
+        """No agent section when AGENT_NAME is empty."""
+        rc, _, _, outputs = self._run({"AGENT_NAME": ""})
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertNotIn("Agentic Designer", prompt)
+        self.assertNotIn("Agentic Developer", prompt)
+
+    def test_ordering_instructions_before_skills(self):
+        """Instructions should appear before skills in the composed prompt."""
+        rc, _, _, outputs = self._run()
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        instructions_pos = prompt.find("Base Instructions")
+        skills_pos = prompt.find("GitHub Issue Progress")
+        self.assertGreater(instructions_pos, -1)
+        self.assertGreater(skills_pos, -1)
+        self.assertLess(instructions_pos, skills_pos)
+
+    def test_ordering_skills_before_agent(self):
+        """Skills should appear before agent definition."""
+        rc, _, _, outputs = self._run({"AGENT_NAME": "agentic-designer"})
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        skills_pos = prompt.find("GitHub Issue Progress")
+        agent_pos = prompt.find("Agentic Designer")
+        self.assertGreater(skills_pos, -1)
+        self.assertGreater(agent_pos, -1)
+        self.assertLess(skills_pos, agent_pos)
+
+    def test_heredoc_output_format(self):
+        """Output should use heredoc format with COMPOSED_EOF delimiter."""
+        rc, _, _, outputs = self._run()
+        self.assertEqual(rc, 0)
+        self.assertIn("prompt", outputs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/claude-respond/action.yml
+++ b/claude-respond/action.yml
@@ -67,6 +67,19 @@ inputs:
   prompt:
     description: "Text to send to Claude as the prompt."
     required: false
+
+  # Compose prompt configuration
+  agent_name:
+    description: "Agent to load from agents/ directory (e.g., 'agentic-designer')"
+    required: false
+  compose_prompt:
+    description: "Compose prompt from instructions/skills/agent (true/false)"
+    required: false
+    default: "false"
+  issue_comment_id:
+    description: "Tracking comment ID for progress updates"
+    required: false
+
   display_report:
     description: "Show the full Claude Code Report in GitHub Job Summary."
     required: false
@@ -108,6 +121,9 @@ runs:
         additional_permissions: ${{ inputs.additional_permissions }}
         settings: ${{ inputs.settings }}
         prompt: ${{ inputs.prompt }}
+        agent_name: ${{ inputs.agent_name }}
+        compose_prompt: ${{ inputs.compose_prompt }}
+        issue_comment_id: ${{ inputs.issue_comment_id }}
         display_report: ${{ inputs.display_report }}
 
     # Step 2: Generate report and upload artifact


### PR DESCRIPTION
## Summary

- Adds a **prompt composition system** (`compose_prompt.sh`) that assembles instructions, skills, agent definitions, runtime context, and user prompts into a single composed prompt
- Introduces **two agent types**: `agentic-designer` (read-only design phase) and `agentic-developer` (implementation phase), enabling a design→implement workflow
- Creates a **`claude-issue.yml` workflow** with 3 jobs (detect-intent, setup, claude-run) triggered by `@claude` mentions or issue assignment
- Users can override instructions/skills/agents by placing files in `.github/claude-{instructions,skills,agents}/` in their repo

## New files

| File | Purpose |
|------|---------|
| `claude-core/scripts/compose_prompt.sh` | Composes prompt from instructions + skills + agent + context |
| `claude-core/instructions/00-base.md` | Core behavioral rules (no direct pushes, follow patterns) |
| `claude-core/instructions/10-github.md` | GitHub environment (gh CLI, tracking comment rules) |
| `claude-core/skills/github-issue-progress.md` | Tracking comment management via `gh api` PATCH |
| `claude-core/agents/agentic-designer.md` | Read-only design agent |
| `claude-core/agents/agentic-developer.md` | Implementation agent (branch, code, test, PR) |
| `claude-core/tests/test_compose_prompt.py` | 16 tests for compose_prompt.sh |
| `.github/workflows/claude-issue.yml` | Issue-triggered workflow |

## Modified files

- `claude-core/action.yml` — 3 new inputs (`agent_name`, `compose_prompt`, `issue_comment_id`), compose step, conditional prompt
- `claude-respond/action.yml` — same 3 inputs forwarded to core
- Test files updated for new inputs/step count

## Test plan

- [x] `make test` — all 99 tests pass
- [ ] Push branch, verify CI passes
- [ ] Manual test: create issue, `@claude` mention, verify tracking comment + agent execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)