### PR TITLE
Fix critical bugs in claude-issue workflow

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -23,12 +23,12 @@ jobs:
     steps:
       - name: Detect intent
         id: detect
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
         run: |
           echo "issue_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
 
-          BODY="${{ github.event.comment.body || '' }}"
-
-          if [[ "$BODY" == *"@claude implement"* ]]; then
+          if [[ "$COMMENT_BODY" == *"@claude implement"* ]]; then
             echo "agent=agentic-developer" >> "$GITHUB_OUTPUT"
           else
             echo "agent=agentic-designer" >> "$GITHUB_OUTPUT"
@@ -58,24 +58,25 @@ jobs:
 
       - name: Create tracking comment
         id: create-comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ needs.detect-intent.outputs.issue_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          COMMENT_ID=$(gh api \
-            --method POST \
-            "/repos/${{ github.repository }}/issues/${{ needs.detect-intent.outputs.issue_number }}/comments" \
-            -f body="$(cat <<'EOF'
-          <!-- claude-tracking-comment -->
+          BODY="<!-- claude-tracking-comment -->
 
           ## Status: Initializing
 
-          **Run:** [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          **Run:** [View workflow run](${RUN_URL})
 
-          Claude is initializing...
-          EOF
-          )" \
+          Claude is initializing..."
+
+          COMMENT_ID=$(gh api \
+            --method POST \
+            "/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments" \
+            -f body="$BODY" \
             --jq '.id')
           echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
 
   # Job 3: Run Claude with composed prompt
@@ -95,6 +96,8 @@ jobs:
         uses: ./claude-respond
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+          trigger_phrase: "@claude"
+          assignee_trigger: "claude"
           compose_prompt: "true"
           agent_name: ${{ needs.detect-intent.outputs.agent }}
           issue_comment_id: ${{ needs.setup.outputs.comment_id }}

--- a/docs/testing-rubric.md
+++ b/docs/testing-rubric.md
@@ -1,0 +1,131 @@
+# Issue-Triggered Claude Workflows: Testing Rubric
+
+## Overview
+
+This rubric defines test scenarios for the issue-triggered Claude workflow system.
+Each scenario specifies the trigger, expected behavior, and pass/fail criteria.
+
+---
+
+## Test Scenarios
+
+### Scenario 1: Designer Agent — Simple Task
+
+**Trigger:** Create issue, comment `@claude`
+
+**Issue:**
+> Title: Add a hello-world shell script
+>
+> Add a simple `hello.sh` script to the repo root that prints "Hello, World!"
+> and exits with code 0. Include a basic test.
+
+**Expected behavior:**
+1. ✅ Workflow triggers (`claude-issue.yml` → `detect-intent` → `agentic-designer`)
+2. ✅ 🚀 reaction appears on the `@claude` comment
+3. ✅ Tracking comment created with "Initializing" status and run link
+4. ✅ Claude runs the designer agent (read-only, no code changes)
+5. ✅ Tracking comment updated with a design document containing:
+   - Summary of proposed changes
+   - Files to create/modify
+   - Implementation approach
+   - Test plan
+6. ✅ Status set to "Needs Input"
+7. ✅ Footer says: "To implement this design, comment: `@claude implement`"
+8. ❌ No branches created, no PRs opened, no files modified
+
+**Pass criteria:** 6/8 checks pass (tracking comment + design doc are critical)
+
+---
+
+### Scenario 2: Developer Agent — Implement After Design
+
+**Trigger:** Comment `@claude implement` on an issue that has a design
+
+**Prerequisite:** Scenario 1 completed successfully (design posted)
+
+**Expected behavior:**
+1. ✅ Workflow triggers with `agentic-developer` agent
+2. ✅ 🚀 reaction on the `@claude implement` comment
+3. ✅ New tracking comment created with "Initializing" status
+4. ✅ Claude creates a feature branch (`claude/{issue_number}-*`)
+5. ✅ Claude implements the changes described in the design
+6. ✅ Claude runs tests (if applicable)
+7. ✅ Claude opens a PR with `Closes #{issue_number}` in the body
+8. ✅ Tracking comment updated to "Completed" with PR link
+
+**Pass criteria:** PR opened with working implementation matching the design
+
+---
+
+### Scenario 3: Designer Agent — Multi-File Refactor
+
+**Trigger:** Create issue, comment `@claude`
+
+**Issue:**
+> Title: Rename claude-core instructions directory to prompts/
+>
+> Rename `claude-core/instructions/` to `claude-core/prompts/` and update
+> all references in `compose_prompt.sh` and tests. This is a refactoring
+> exercise — no behavioral changes.
+
+**Expected behavior:**
+- Designer produces a design listing all files to modify
+- Design correctly identifies compose_prompt.sh and test_compose_prompt.py
+- No code changes made (designer is read-only)
+
+**Pass criteria:** Design identifies all affected files accurately
+
+---
+
+### Scenario 4: Edge Case — No @claude Mention
+
+**Trigger:** Create issue, comment without `@claude`
+
+**Expected behavior:**
+- Workflow does NOT trigger (or triggers but `detect-intent` gates it)
+- No tracking comment, no reactions
+
+**Pass criteria:** No workflow activity
+
+---
+
+### Scenario 5: Edge Case — PR Comment (Should Skip)
+
+**Trigger:** Comment `@claude` on a pull request
+
+**Expected behavior:**
+- `claude-issue.yml` should NOT trigger (it filters out PR-linked issues)
+- The existing `test-claude-respond.yml` may handle this separately
+
+**Pass criteria:** `claude-issue.yml` does not run
+
+---
+
+## Evaluation Scoring
+
+For each scenario, score on these dimensions:
+
+| Dimension | Weight | Criteria |
+|-----------|--------|----------|
+| **Trigger correctness** | 20% | Right workflow fires, right agent selected |
+| **Setup phase** | 15% | Reaction added, tracking comment created with run link |
+| **Agent behavior** | 30% | Agent follows its role (designer=read-only, developer=implements) |
+| **Output quality** | 20% | Design is thorough / PR is clean and working |
+| **Comment management** | 15% | Tracking comment updated properly, correct status |
+
+**Overall score = weighted sum across dimensions**
+
+- **Excellent (90-100%):** All critical paths work, output is high quality
+- **Good (70-89%):** Core flow works, minor issues with output or tracking
+- **Needs Work (50-69%):** Flow triggers but agent behavior is off
+- **Broken (<50%):** Workflow doesn't trigger or fails early
+
+---
+
+## Iteration Log
+
+Track test runs and fixes here:
+
+| Run | Date | Scenario | Score | Issues Found | Fix PR |
+|-----|------|----------|-------|-------------|--------|
+| | | | | | |


### PR DESCRIPTION
## Summary

- **Fix heredoc bash error:** The tracking comment creation used `<<'EOF'` with an indented closing `EOF` delimiter, which would cause a syntax error at runtime
- **Fix shell injection vulnerability:** Comment body was directly interpolated into bash via `${{ }}` — moved to `env:` block to prevent arbitrary command execution
- **Add missing trigger inputs:** `trigger_phrase` and `assignee_trigger` were not passed to the upstream action, which could cause it to skip processing

## Test plan

- [x] CI passes (no test changes needed — workflow-only fixes)
- [ ] Live test: create issue, comment `@claude`, verify workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)