### PR TITLE
Fix setup job permissions and comment formatting

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: detect-intent
     if: needs.detect-intent.outputs.should_run == 'true'
+    permissions:
+      issues: write
     outputs:
       comment_id: ${{ steps.create-comment.outputs.comment_id }}
     steps:
@@ -64,12 +66,11 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           BODY="<!-- claude-tracking-comment -->
+## Status: Initializing
 
-          ## Status: Initializing
+**Run:** [View workflow run](${RUN_URL})
 
-          **Run:** [View workflow run](${RUN_URL})
-
-          Claude is initializing..."
+Claude is initializing..."
 
           COMMENT_ID=$(gh api \
             --method POST \


### PR DESCRIPTION
## Summary

- Add `permissions: issues: write` to setup job — the reactions API requires issue write permission, causing a 403 error on the rocket reaction step
- Fix tracking comment body indentation — YAML block scalar `|` was preserving leading whitespace in the markdown

Found during live testing of Scenario 1 (issue #18).

## Test plan

- [x] CI passes
- [ ] Re-test with issue #18 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)