### PR TITLE
Fix workflow conflict: split issue vs PR comment handling

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       !github.event.issue.pull_request
+      && github.event.sender.type != 'Bot'
       && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
         || (github.event_name == 'issues' && github.event.action == 'assigned')

--- a/.github/workflows/test-claude-respond.yml
+++ b/.github/workflows/test-claude-respond.yml
@@ -1,13 +1,9 @@
 name: "Test: Claude Respond"
 
 on:
-  # Production triggers — only fire from default branch
-  issue_comment:
-    types: [created]
+  # PR comment triggers — issue comments are handled by claude-issue.yml
   pull_request_review_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
 
   # Dev trigger — works from any branch: gh workflow run "Test: Claude Respond" --ref <branch>
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Remove `issue_comment` and `issues` triggers from `test-claude-respond.yml` — these are now handled exclusively by `claude-issue.yml`
- Add `github.event.sender.type != 'Bot'` check to `claude-issue.yml` to prevent Claude's own comments from re-triggering the workflow (was causing an infinite comment cascade)

Found during live testing: both workflows were firing on the same `issue_comment` events, and Claude's response comments were triggering additional runs.

## Test plan

- [x] CI passes
- [ ] Create test issue, comment `@claude`, verify only `claude-issue.yml` fires
- [ ] Verify no comment cascade from bot responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)