### PR TITLE
Add allowed_tools to enable Claude CLI commands in CI

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -100,3 +100,4 @@ jobs:
           compose_prompt: "true"
           agent_name: ${{ needs.detect-intent.outputs.agent }}
           issue_comment_id: ${{ needs.setup.outputs.comment_id }}
+          allowed_tools: "Bash(*),Read,Glob,Grep,Edit,Write,WebFetch,WebSearch"


### PR DESCRIPTION
## Summary

- Add `allowed_tools: "Bash(*),Read,Glob,Grep,Edit,Write,WebFetch,WebSearch"` to the `claude-run` job
- Without this, Claude's `Bash` tool requires interactive user approval — in CI, all 39 `gh` CLI calls were silently denied, preventing Claude from reading issues or updating the tracking comment

## Root cause

Claude Code runs in `permissionMode: "default"` which requires user approval for Bash commands. In a GitHub Actions context there's no interactive user, so all `Bash` tool calls were denied. The `allowed_tools` input pre-authorizes specific tools.

## Test plan

- [x] CI passes
- [ ] Re-test with issue #23 or new issue after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)