### PR TITLE
Improve messaging with run links, add gh CLI setup

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -91,6 +91,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Setup GitHub CLI
+        uses: actions4gh/setup-gh@10aaae734648c536041e1bce50fc8c5541806255 # v1
+
       - name: Run Claude
         uses: ./claude-respond
         with:

--- a/claude-core/agents/agentic-designer.md
+++ b/claude-core/agents/agentic-designer.md
@@ -20,6 +20,14 @@ Your design should include:
 - **Test Plan** — what tests to write and what they should cover.
 - **Open Questions** — anything you need clarified before implementation.
 
+## Linking to the Workflow Run
+
+Always include the workflow run link in your tracking comment so reviewers can inspect the logs. The run URL is provided in the runtime context as `RUN_URL`. Use it in your tracking comment header:
+
+```
+**Run:** [View workflow run](<RUN_URL>)
+```
+
 ## Footer
 
 End the design with:

--- a/claude-core/agents/agentic-developer.md
+++ b/claude-core/agents/agentic-developer.md
@@ -13,7 +13,18 @@ You are operating as an **implementation agent**. Your job is to read an approve
    - A clear title summarizing the change.
    - `Closes #ISSUE_NUMBER` in the PR body to auto-close the issue on merge.
    - A summary of what was implemented and any deviations from the design.
-7. **Update tracking comment** — set status to "Completed" with a link to the PR.
+   - A link to the workflow run: `**Run:** [View workflow run](<RUN_URL>)`
+7. **Update tracking comment** — set status to "Completed" with a link to the PR and the workflow run.
+
+## Linking to the Workflow Run
+
+Always include the workflow run link in both the tracking comment and the PR body. The run URL is provided in the runtime context as `RUN_URL`. Include it as:
+
+```
+**Run:** [View workflow run](<RUN_URL>)
+```
+
+This lets reviewers quickly navigate to the CI logs that produced the changes.
 
 ## Rules
 

--- a/claude-core/instructions/10-github.md
+++ b/claude-core/instructions/10-github.md
@@ -12,3 +12,9 @@
 - **Never create new top-level comments** on the issue — always update the existing tracking comment.
 - The tracking comment ID is provided in the runtime context below.
 - Use `gh api` with PATCH to update the comment body.
+
+## Workflow Run Links
+
+- The workflow run URL is provided in the runtime context as `Run URL`.
+- **Always include this link** in your tracking comment and any PR you create so reviewers can navigate to the CI logs.
+- Format: `**Run:** [View workflow run](<URL>)`

--- a/claude-core/skills/github-issue-progress.md
+++ b/claude-core/skills/github-issue-progress.md
@@ -32,6 +32,8 @@ COMMENT_EOF
 )"
 ```
 
+**Important:** Replace `<RUN_URL>` with the actual run URL from the runtime context. This is provided as the `Run URL` field. Always include this link so reviewers can navigate directly to the workflow logs.
+
 Replace `<STATUS>` with one of:
 - **In Progress** — actively working
 - **Needs Input** — blocked, waiting for human feedback
@@ -42,6 +44,6 @@ Replace `<STATUS>` with one of:
 
 1. Update the tracking comment at meaningful milestones (starting work, design posted, PR created, blocked).
 2. Always preserve the `<!-- claude-tracking-comment -->` HTML marker as the first line.
-3. Include the workflow run link so reviewers can inspect logs.
+3. Always include the workflow run link (`**Run:** [View workflow run](...)`) so reviewers can inspect logs.
 4. When blocked or needing clarification, set status to **Needs Input** and clearly describe what you need.
 5. Keep the comment body concise — use `<details>` blocks for verbose content.


### PR DESCRIPTION
## Summary

- **Run links in agent output:** Updated both agent definitions (designer + developer) and the progress tracking skill to explicitly require workflow run links in tracking comments and PR bodies. This ensures every post from Claude links back to the CI logs.
- **gh CLI setup:** Added `actions4gh/setup-gh@v1` step to ensure the `gh` CLI is installed and cached on self-hosted runners (it's pre-installed on GitHub-hosted runners but not guaranteed on custom ones).

## Files changed

| File | Change |
|------|--------|
| `claude-core/agents/agentic-designer.md` | Added "Linking to the Workflow Run" section |
| `claude-core/agents/agentic-developer.md` | Added run link requirement for PR body + tracking comment |
| `claude-core/skills/github-issue-progress.md` | Emphasized replacing `<RUN_URL>` with actual URL |
| `claude-core/instructions/10-github.md` | Added "Workflow Run Links" section |
| `.github/workflows/claude-issue.yml` | Added `actions4gh/setup-gh` step before Claude run |

## Test plan

- [x] `make test` — all 99 tests pass
- [x] YAML validates
- [ ] Live test after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)