### PR TITLE
Remove broken actions4gh/setup-gh from issue workflow

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -91,9 +91,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup GitHub CLI
-        uses: actions4gh/setup-gh@10aaae734648c536041e1bce50fc8c5541806255 # v1
-
       - name: Run Claude
         uses: ./claude-respond
         with:


### PR DESCRIPTION
## Summary
- Removes the `actions4gh/setup-gh` step from the `claude-issue.yml` workflow
- The action at the pinned SHA has no `dist/main.js`, causing the claude-run job to fail before Claude even starts
- The `gh` CLI is already pre-installed on the self-hosted runner, so this step was unnecessary

## Context
Issue #29's designer run (22693336280) failed because of this broken action. This fix unblocks all future issue-triggered Claude runs.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, trigger designer agent on issue #29 and verify it runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)