### PR TITLE
fix(workflows): add pull-requests write to setup job for PR comments

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -62,6 +62,7 @@ jobs:
     if: needs.detect-intent.outputs.should_run == 'true'
     permissions:
       issues: write
+      pull-requests: write
     outputs:
       comment_id: ${{ steps.create-comment.outputs.comment_id }}
     steps:


### PR DESCRIPTION
## Summary

- Add `pull-requests: write` to the `setup` job permissions
- The reaction API returns 403 when reacting to comments on PRs with only `issues: write`

Fixes the failure at https://github.com/diranged/claude-code-agentic-workflows/actions/runs/22702653026/job/65823070224

## Test plan

- [ ] Comment `@claude` on PR #63 → rocket reaction added, workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)