### PR TITLE
fix(workflows): stop workflow_run events from entering detect-intent

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -27,7 +27,6 @@ jobs:
       || (github.event_name == 'issues' && github.event.action == 'labeled'
         && !github.event.issue.pull_request
         && startsWith(github.event.label.name, 'claude:'))
-      || (github.event_name == 'workflow_run')
     outputs:
       should_run: ${{ steps.detect.outputs.should_run }}
       agent: ${{ steps.detect.outputs.agent }}


### PR DESCRIPTION
## Summary

- Remove `|| (github.event_name == 'workflow_run')` from the `detect-intent` job's `if` condition
- `workflow_run` events don't have `issue.number`, so they caused empty `issue_number` → 404 on tracking comment creation
- The `ci-retry` job already has its own `if` guard for `workflow_run` events — it doesn't need to go through `detect-intent`

Fixes the spurious failures seen at:
- https://github.com/diranged/claude-code-agentic-workflows/actions/runs/22702740152
- https://github.com/diranged/claude-code-agentic-workflows/actions/runs/22702749093

## Test plan

- [ ] `workflow_run` events no longer trigger detect-intent/setup/claude-run
- [ ] `ci-retry` job still evaluates independently on `workflow_run` events
- [ ] `@claude` on issues and PRs still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)