### PR TITLE
refactor(agents): remove hardcoded intent routing, let Claude decide

### DIFF
--- a/claude-core/scripts/detect_intent.sh
+++ b/claude-core/scripts/detect_intent.sh
@@ -36,57 +36,11 @@ elif [[ "$label" == claude:* ]]; then
   exit 0
 fi
 
-# --- Comment-body routing ---
-body="$(echo "${COMMENT_BODY:-}" | tr '[:upper:]' '[:lower:]')"
-
-# Routing table: first match wins
-if [[ "$body" =~ @claude[[:space:]]+implement ]] || [[ "$body" =~ implement[[:space:]]+(this|the|it|now) ]]; then
-  agent="agentic-developer"
-  model="claude-sonnet-4-20250514"
-
-elif [[ "$body" =~ dead[[:space:]]*code ]] || [[ "$body" =~ stale ]] || \
-     [[ "$body" =~ (^|[[:space:]])todo([[:space:]]|$) ]] || [[ "$body" =~ cleanup ]] || \
-     [[ "$body" =~ janitor ]] || [[ "$body" =~ (^|[[:space:]])unused([[:space:]]|$) ]] || \
-     [[ "$body" =~ deprecated ]] || [[ "$body" =~ outdated[[:space:]]*dep ]]; then
-  agent="janitor"
-  model="claude-sonnet-4-20250514"
-
-elif [[ "$body" =~ performance ]] || [[ "$body" =~ n\+1 ]] || \
-     [[ "$body" =~ memory[[:space:]]*leak ]] || [[ "$body" =~ bundle[[:space:]]*size ]] || \
-     [[ "$body" =~ (^|[[:space:]])slow([[:space:]]|$) ]] || [[ "$body" =~ latency ]] || \
-     [[ "$body" =~ (^|[[:space:]])perf([[:space:]]|$) ]]; then
-  agent="performance-reviewer"
-  model="claude-sonnet-4-20250514"
-
-elif [[ "$body" =~ documentation ]] || [[ "$body" =~ (^|[[:space:]])docs?([[:space:]]|$) ]] || \
-     [[ "$body" =~ readme ]] || [[ "$body" =~ broken[[:space:]]*link ]] || \
-     [[ "$body" =~ api[[:space:]]*doc ]] || [[ "$body" =~ changelog ]]; then
-  agent="docs-reviewer"
-  model="claude-sonnet-4-20250514"
-
-elif [[ "$body" =~ (^|[[:space:]])tests?([[:space:]]|$) ]] || [[ "$body" =~ coverage ]] || \
-     [[ "$body" =~ flaky ]] || [[ "$body" =~ untested ]] || \
-     [[ "$body" =~ edge[[:space:]]*case ]] || [[ "$body" =~ (^|[[:space:]])spec([[:space:]]|$) ]]; then
-  agent="test-coverage"
-  model="claude-sonnet-4-20250514"
-
-elif [[ "$body" =~ architect ]] || [[ "$body" =~ coupling ]] || \
-     [[ "$body" =~ abstraction ]] || [[ "$body" =~ api[[:space:]]*design ]] || \
-     [[ "$body" =~ scalab ]] || [[ "$body" =~ layering ]] || \
-     [[ "$body" =~ circular[[:space:]]*dep ]] || [[ "$body" =~ design[[:space:]]*review ]]; then
-  agent="architect"
-  model="claude-opus-4-20250514"
-
-elif [[ "$body" =~ review ]]; then
-  # Generic "review" catch-all → architect
-  agent="architect"
-  model="claude-opus-4-20250514"
-
-else
-  # Default: design phase
-  agent="agentic-designer"
-  model="claude-opus-4-20250514"
-fi
+# --- Comment-based routing ---
+# No keyword matching — Claude figures out intent from the comment body.
+# Default to the developer agent (most capable, can read + write).
+agent="agentic-developer"
+model="claude-sonnet-4-20250514"
 
 echo "agent=${agent}" >> "$GITHUB_OUTPUT"
 echo "model=${model}" >> "$GITHUB_OUTPUT"

--- a/claude-core/tests/test_detect_intent.py
+++ b/claude-core/tests/test_detect_intent.py
@@ -17,153 +17,6 @@ class TestDetectIntent(unittest.TestCase):
         self.assertEqual(rc, 0, f"Script failed: {stderr}")
         return outputs
 
-    # --- implement ---
-
-    def test_implement_direct(self):
-        outputs = self._run("@claude implement")
-        self.assertEqual(outputs["agent"], "agentic-developer")
-        self.assertEqual(outputs["model"], "claude-sonnet-4-20250514")
-
-    def test_implement_this(self):
-        outputs = self._run("@claude implement this")
-        self.assertEqual(outputs["agent"], "agentic-developer")
-
-    def test_implement_case_insensitive(self):
-        outputs = self._run("@Claude Implement This")
-        self.assertEqual(outputs["agent"], "agentic-developer")
-
-    # --- janitor ---
-
-    def test_janitor_dead_code(self):
-        outputs = self._run("@claude check for dead code")
-        self.assertEqual(outputs["agent"], "janitor")
-
-    def test_janitor_stale(self):
-        outputs = self._run("@claude find stale references")
-        self.assertEqual(outputs["agent"], "janitor")
-
-    def test_janitor_todo(self):
-        outputs = self._run("@claude review TODO items")
-        self.assertEqual(outputs["agent"], "janitor")
-
-    def test_janitor_cleanup(self):
-        outputs = self._run("@claude cleanup the codebase")
-        self.assertEqual(outputs["agent"], "janitor")
-
-    def test_janitor_deprecated(self):
-        outputs = self._run("@claude find deprecated APIs")
-        self.assertEqual(outputs["agent"], "janitor")
-
-    def test_janitor_unused(self):
-        outputs = self._run("@claude find unused imports")
-        self.assertEqual(outputs["agent"], "janitor")
-
-    # --- performance-reviewer ---
-
-    def test_perf_performance(self):
-        outputs = self._run("@claude check performance")
-        self.assertEqual(outputs["agent"], "performance-reviewer")
-
-    def test_perf_n_plus_1(self):
-        outputs = self._run("@claude look for N+1 queries")
-        self.assertEqual(outputs["agent"], "performance-reviewer")
-
-    def test_perf_memory_leak(self):
-        outputs = self._run("@claude check for memory leak issues")
-        self.assertEqual(outputs["agent"], "performance-reviewer")
-
-    def test_perf_slow(self):
-        outputs = self._run("@claude this endpoint is slow")
-        self.assertEqual(outputs["agent"], "performance-reviewer")
-
-    # --- docs-reviewer ---
-
-    def test_docs_documentation(self):
-        outputs = self._run("@claude review documentation")
-        self.assertEqual(outputs["agent"], "docs-reviewer")
-
-    def test_docs_readme(self):
-        outputs = self._run("@claude check the README")
-        self.assertEqual(outputs["agent"], "docs-reviewer")
-
-    def test_docs_broken_link(self):
-        outputs = self._run("@claude find broken link issues")
-        self.assertEqual(outputs["agent"], "docs-reviewer")
-
-    def test_docs_doc_singular(self):
-        outputs = self._run("@claude review the doc")
-        self.assertEqual(outputs["agent"], "docs-reviewer")
-
-    # --- test-coverage ---
-
-    def test_coverage_tests(self):
-        outputs = self._run("@claude review tests")
-        self.assertEqual(outputs["agent"], "test-coverage")
-
-    def test_coverage_coverage(self):
-        outputs = self._run("@claude check coverage gaps")
-        self.assertEqual(outputs["agent"], "test-coverage")
-
-    def test_coverage_flaky(self):
-        outputs = self._run("@claude find flaky tests")
-        self.assertEqual(outputs["agent"], "test-coverage")
-
-    def test_coverage_untested(self):
-        outputs = self._run("@claude find untested code")
-        self.assertEqual(outputs["agent"], "test-coverage")
-
-    def test_coverage_edge_case(self):
-        outputs = self._run("@claude check for edge case coverage")
-        self.assertEqual(outputs["agent"], "test-coverage")
-
-    # --- architect ---
-
-    def test_architect_direct(self):
-        outputs = self._run("@claude architect review")
-        self.assertEqual(outputs["agent"], "architect")
-        self.assertEqual(outputs["model"], "claude-opus-4-20250514")
-
-    def test_architect_coupling(self):
-        outputs = self._run("@claude check for coupling issues")
-        self.assertEqual(outputs["agent"], "architect")
-
-    def test_architect_design_review(self):
-        outputs = self._run("@claude do a design review")
-        self.assertEqual(outputs["agent"], "architect")
-
-    # --- generic review catch-all → architect ---
-
-    def test_review_catchall(self):
-        outputs = self._run("@claude review this issue")
-        self.assertEqual(outputs["agent"], "architect")
-        self.assertEqual(outputs["model"], "claude-opus-4-20250514")
-
-    # --- default fallback → agentic-designer ---
-
-    def test_default_bare_claude(self):
-        outputs = self._run("@claude")
-        self.assertEqual(outputs["agent"], "agentic-designer")
-        self.assertEqual(outputs["model"], "claude-opus-4-20250514")
-
-    def test_default_unrecognized(self):
-        outputs = self._run("@claude do something random")
-        self.assertEqual(outputs["agent"], "agentic-designer")
-
-    # --- edge cases ---
-
-    def test_empty_body(self):
-        outputs = self._run("")
-        self.assertEqual(outputs["agent"], "agentic-designer")
-
-    def test_multiline_body(self):
-        body = "Hey team,\n\n@claude implement this feature\n\nThanks!"
-        outputs = self._run(body)
-        self.assertEqual(outputs["agent"], "agentic-developer")
-
-    def test_mid_sentence(self):
-        outputs = self._run("Can you @claude review the architecture?")
-        self.assertEqual(outputs["agent"], "architect")
-
     # --- label-based routing ---
 
     def test_label_implement(self):
@@ -186,7 +39,7 @@ class TestDetectIntent(unittest.TestCase):
         self.assertEqual(outputs["agent"], "agentic-designer")
 
     def test_label_takes_priority_over_comment(self):
-        """Label routing should override comment body routing."""
+        """Label routing should override comment body."""
         outputs = self._run(
             comment_body="@claude implement this",
             trigger_label="claude:review",
@@ -194,17 +47,42 @@ class TestDetectIntent(unittest.TestCase):
         self.assertEqual(outputs["agent"], "architect")
 
     def test_non_claude_label_falls_through(self):
-        """Non-claude: labels should fall through to comment body routing."""
+        """Non-claude: labels should fall through to default."""
         outputs = self._run(
-            comment_body="@claude implement",
+            comment_body="@claude do something",
             trigger_label="bug",
         )
         self.assertEqual(outputs["agent"], "agentic-developer")
 
     def test_empty_label_falls_through(self):
-        """Empty label should fall through to comment body routing."""
-        outputs = self._run(comment_body="@claude check performance")
-        self.assertEqual(outputs["agent"], "performance-reviewer")
+        """Empty label should fall through to default."""
+        outputs = self._run(comment_body="@claude check something")
+        self.assertEqual(outputs["agent"], "agentic-developer")
+
+    # --- comment-based routing (always developer) ---
+
+    def test_comment_defaults_to_developer(self):
+        """Any @claude comment should route to the developer agent."""
+        outputs = self._run("@claude rebase this")
+        self.assertEqual(outputs["agent"], "agentic-developer")
+        self.assertEqual(outputs["model"], "claude-sonnet-4-20250514")
+
+    def test_empty_body_defaults_to_developer(self):
+        outputs = self._run("")
+        self.assertEqual(outputs["agent"], "agentic-developer")
+
+    def test_any_comment_goes_to_developer(self):
+        """Claude figures out intent — no keyword matching."""
+        for comment in [
+            "@claude review the architecture",
+            "@claude fix the tests",
+            "@claude check for dead code",
+            "@claude do something random",
+            "@claude",
+        ]:
+            with self.subTest(comment=comment):
+                outputs = self._run(comment)
+                self.assertEqual(outputs["agent"], "agentic-developer")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Remove all keyword regex routing from `detect_intent.sh`
- All `@claude` comments now default to the developer agent — Claude reads the comment body and figures out what to do
- Label-based routing (`claude:design`, `claude:review`, `claude:implement`) still works for explicit control
- Simplifies `detect_intent.sh` from 90+ lines to ~20 lines

The old approach tried to parse intent with regex ("rebase" → developer, "dead code" → janitor, etc.) but was brittle and couldn't cover all cases. Claude itself is the best intent parser.

## Test plan

- [x] All tests pass (149 total)
- [ ] `@claude rebase this` on a PR → developer agent runs
- [ ] `claude:review` label → still routes to architect

🤖 Generated with [Claude Code](https://claude.com/claude-code)