### PR TITLE
feat(claude-core): add intelligent auto agent routing

### DIFF
--- a/claude-core/scripts/compose_prompt.sh
+++ b/claude-core/scripts/compose_prompt.sh
@@ -53,7 +53,56 @@ load_dir "${ACTION_PATH}/skills"
 load_dir "${WORKSPACE_PATH}/.github/claude-skills"
 
 # --- 6. Agent definition ---
-if [ -n "${AGENT_NAME:-}" ]; then
+if [ "${AGENT_NAME:-}" = "auto" ]; then
+  # Dynamic agent catalog — Claude self-selects the right role
+  CATALOG="# Intelligent Agent Selection"$'\n\n'
+  CATALOG="${CATALOG}You have multiple specialized agent roles available. Analyze the task context at the end of this prompt and adopt the most appropriate role."$'\n\n'
+  CATALOG="${CATALOG}## Available Agents"$'\n\n'
+
+  # Collect agents with deduplication (user override > extra > built-in)
+  _seen_agents=""
+  _add_agent() {
+    local name="$1" file="$2"
+    case ",$_seen_agents," in
+      *",$name,"*) return ;;
+    esac
+    _seen_agents="${_seen_agents}${name},"
+    CATALOG="${CATALOG}---"$'\n\n'"$(cat "$file")"$'\n\n'
+  }
+
+  # User overrides first (highest priority)
+  if [ -d "${WORKSPACE_PATH}/.github/claude-agents" ]; then
+    for f in "${WORKSPACE_PATH}/.github/claude-agents/"*.md; do
+      [ -f "$f" ] || continue
+      _add_agent "$(basename "$f" .md)" "$f"
+    done
+  fi
+
+  # Extra agents path (e.g., claude-engineer agents)
+  if [ -n "${EXTRA_AGENTS_PATH:-}" ] && [ -d "${EXTRA_AGENTS_PATH}" ]; then
+    for f in "${EXTRA_AGENTS_PATH}/"*.md; do
+      [ -f "$f" ] || continue
+      _add_agent "$(basename "$f" .md)" "$f"
+    done
+  fi
+
+  # Built-in agents
+  for f in "${ACTION_PATH}/agents/"*.md; do
+    [ -f "$f" ] || continue
+    _add_agent "$(basename "$f" .md)" "$f"
+  done
+
+  CATALOG="${CATALOG}---"$'\n\n'
+  CATALOG="${CATALOG}## Selection Instructions"$'\n\n'
+  CATALOG="${CATALOG}1. Read the task context carefully to understand the user's intent"$'\n'
+  CATALOG="${CATALOG}2. Choose the single most appropriate agent role from those listed above"$'\n'
+  CATALOG="${CATALOG}3. Adopt that role's behavior, constraints, and output format completely"$'\n'
+  CATALOG="${CATALOG}4. If the user explicitly mentions a role (e.g., \"use the design agent\"), follow their preference"$'\n'
+  CATALOG="${CATALOG}5. If the request doesn't clearly match a specialized role, default to **Agentic Developer** (the most versatile role with read/write access)"$'\n'
+  CATALOG="${CATALOG}6. State which role you've adopted at the beginning of your response"$'\n'
+
+  append_section "$CATALOG"
+elif [ -n "${AGENT_NAME:-}" ]; then
   AGENT_FILE=""
   USER_AGENT="${WORKSPACE_PATH}/.github/claude-agents/${AGENT_NAME}.md"
   EXTRA_AGENT="${EXTRA_AGENTS_PATH:+${EXTRA_AGENTS_PATH}/${AGENT_NAME}.md}"

--- a/claude-core/scripts/detect_intent.sh
+++ b/claude-core/scripts/detect_intent.sh
@@ -38,8 +38,8 @@ fi
 
 # --- Comment-based routing ---
 # No keyword matching — Claude figures out intent from the comment body.
-# Default to the developer agent (most capable, can read + write).
-agent="agentic-developer"
+# "auto" mode includes all agent definitions so Claude self-selects the right role.
+agent="auto"
 model="claude-sonnet-4-20250514"
 
 echo "agent=${agent}" >> "$GITHUB_OUTPUT"

--- a/claude-core/scripts/validate_inputs.sh
+++ b/claude-core/scripts/validate_inputs.sh
@@ -62,7 +62,8 @@ if [ "${COMPOSE_PROMPT:-}" = "true" ] && [ -z "${AGENT_NAME:-}" ]; then
 fi
 
 # 5. Agent file must exist (when compose_prompt=true and agent_name is set)
-if [ "${COMPOSE_PROMPT:-}" = "true" ] && [ -n "${AGENT_NAME:-}" ]; then
+# "auto" is a special routing mode — no agent file needed.
+if [ "${COMPOSE_PROMPT:-}" = "true" ] && [ -n "${AGENT_NAME:-}" ] && [ "${AGENT_NAME}" != "auto" ]; then
   USER_AGENT="${WORKSPACE_PATH:-.}/.github/claude-agents/${AGENT_NAME}.md"
   EXTRA_AGENT="${EXTRA_AGENTS_PATH:+${EXTRA_AGENTS_PATH}/${AGENT_NAME}.md}"
   BUILTIN_AGENT="${ACTION_PATH:-.}/agents/${AGENT_NAME}.md"

--- a/claude-core/tests/test_compose_prompt.py
+++ b/claude-core/tests/test_compose_prompt.py
@@ -364,6 +364,69 @@ class TestComposePrompt(unittest.TestCase):
         self.assertIn("User Override Agent", prompt)
         self.assertNotIn("Extra Path Agent", prompt)
 
+    # --- auto agent mode ---
+
+    def test_auto_includes_agent_catalog(self):
+        """auto mode should include all built-in agent definitions."""
+        rc, _, _, outputs = self._run({"AGENT_NAME": "auto"})
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertIn("Intelligent Agent Selection", prompt)
+        self.assertIn("Available Agents", prompt)
+        self.assertIn("Selection Instructions", prompt)
+
+    def test_auto_includes_all_builtin_agents(self):
+        """auto mode should include every built-in agent."""
+        rc, _, _, outputs = self._run({"AGENT_NAME": "auto"})
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        for agent_name in [
+            "Agentic Designer",
+            "Agentic Developer",
+            "Architect",
+            "Docs Reviewer",
+            "Janitor",
+            "Performance Reviewer",
+            "Test Coverage Reviewer",
+        ]:
+            with self.subTest(agent=agent_name):
+                self.assertIn(agent_name, prompt)
+
+    def test_auto_includes_extra_agents(self):
+        """auto mode should include agents from extra_agents_path."""
+        engineer_agents = os.path.join(CORE_DIR, "..", "claude-engineer", "agents")
+        rc, _, _, outputs = self._run({
+            "AGENT_NAME": "auto",
+            "EXTRA_AGENTS_PATH": engineer_agents,
+        })
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertIn("Documentation Engineer", prompt)
+        self.assertIn("Code Janitor", prompt)
+
+    def test_auto_user_override_deduplicates(self):
+        """User agent override should replace built-in in auto catalog."""
+        workspace = tempfile.mkdtemp()
+        override_dir = os.path.join(workspace, ".github", "claude-agents")
+        os.makedirs(override_dir)
+        with open(os.path.join(override_dir, "agentic-designer.md"), "w") as f:
+            f.write("# Agent: Custom Designer Override\n\nCustom behavior.\n")
+
+        rc, _, _, outputs = self._run({"AGENT_NAME": "auto"}, workspace=workspace)
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertIn("Custom Designer Override", prompt)
+        # Built-in designer content should NOT appear (user override takes priority)
+        self.assertNotIn("read-only architectural", prompt.lower())
+
+    def test_auto_includes_selection_instructions(self):
+        """auto mode should include instructions for Claude to self-select."""
+        rc, _, _, outputs = self._run({"AGENT_NAME": "auto"})
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        self.assertIn("Agentic Developer", prompt)
+        self.assertIn("most appropriate agent role", prompt)
+
     def test_heredoc_output_format(self):
         """Output should use heredoc format with COMPOSED_EOF delimiter."""
         rc, _, _, outputs = self._run()

--- a/claude-core/tests/test_detect_intent.py
+++ b/claude-core/tests/test_detect_intent.py
@@ -47,32 +47,32 @@ class TestDetectIntent(unittest.TestCase):
         self.assertEqual(outputs["agent"], "architect")
 
     def test_non_claude_label_falls_through(self):
-        """Non-claude: labels should fall through to default."""
+        """Non-claude: labels should fall through to auto mode."""
         outputs = self._run(
             comment_body="@claude do something",
             trigger_label="bug",
         )
-        self.assertEqual(outputs["agent"], "agentic-developer")
+        self.assertEqual(outputs["agent"], "auto")
 
     def test_empty_label_falls_through(self):
-        """Empty label should fall through to default."""
+        """Empty label should fall through to auto mode."""
         outputs = self._run(comment_body="@claude check something")
-        self.assertEqual(outputs["agent"], "agentic-developer")
+        self.assertEqual(outputs["agent"], "auto")
 
-    # --- comment-based routing (always developer) ---
+    # --- comment-based routing (auto mode) ---
 
-    def test_comment_defaults_to_developer(self):
-        """Any @claude comment should route to the developer agent."""
+    def test_comment_defaults_to_auto(self):
+        """Any @claude comment should route to auto mode."""
         outputs = self._run("@claude rebase this")
-        self.assertEqual(outputs["agent"], "agentic-developer")
+        self.assertEqual(outputs["agent"], "auto")
         self.assertEqual(outputs["model"], "claude-sonnet-4-20250514")
 
-    def test_empty_body_defaults_to_developer(self):
+    def test_empty_body_defaults_to_auto(self):
         outputs = self._run("")
-        self.assertEqual(outputs["agent"], "agentic-developer")
+        self.assertEqual(outputs["agent"], "auto")
 
-    def test_any_comment_goes_to_developer(self):
-        """Claude figures out intent — no keyword matching."""
+    def test_any_comment_goes_to_auto(self):
+        """Claude self-selects the right agent — no keyword matching."""
         for comment in [
             "@claude review the architecture",
             "@claude fix the tests",
@@ -82,7 +82,7 @@ class TestDetectIntent(unittest.TestCase):
         ]:
             with self.subTest(comment=comment):
                 outputs = self._run(comment)
-                self.assertEqual(outputs["agent"], "agentic-developer")
+                self.assertEqual(outputs["agent"], "auto")
 
 
 if __name__ == "__main__":

--- a/claude-core/tests/test_validate_inputs.py
+++ b/claude-core/tests/test_validate_inputs.py
@@ -184,6 +184,20 @@ class TestValidateInputs(unittest.TestCase):
         )
         self.assertEqual(rc, 0)
 
+    def test_succeeds_auto_agent(self):
+        """auto agent mode should pass validation without a file."""
+        rc, stdout, _, _ = run_script(
+            "validate_inputs.sh",
+            {
+                "OAUTH_TOKEN": "tok",
+                "COMPOSE_PROMPT": "true",
+                "AGENT_NAME": "auto",
+                "ACTION_PATH": self.temp_action_path,
+                "WORKSPACE_PATH": self.temp_workspace,
+            },
+        )
+        self.assertEqual(rc, 0)
+
     def test_succeeds_no_compose(self):
         rc, stdout, _, _ = run_script(
             "validate_inputs.sh",


### PR DESCRIPTION
## Summary

- When triggered by `@claude` comments (no label), the system now uses `auto` mode instead of hardcoding `agentic-developer`
- In `auto` mode, `compose_prompt.sh` dynamically builds a catalog of ALL available agent definitions and includes selection instructions so Claude self-selects the right role
- Agent deduplication follows the existing priority chain: user overrides > extra path > built-in
- Label-based routing (`claude:implement`, `claude:review`, `claude:design`) is unchanged

Fixes the scenario where `@claude ... use the design agent to design this` incorrectly routed to the developer agent.

## Test plan

- [x] All 68 claude-core tests pass
- [x] All 19 tests (other suites) pass
- [x] New tests verify auto mode includes all built-in agents, extra agents, user overrides with deduplication, and selection instructions
- [x] `validate_inputs.sh` allows `auto` without requiring an agent file
- [ ] Live test: comment `@claude design this` on an issue and verify designer role is adopted

🤖 Generated with [Claude Code](https://claude.com/claude-code)