### PR TITLE
fix(agents): add issue grouping rules to code-janitor and add claude-agent scope

### DIFF
--- a/.github/workflows/pr-conventional-commit.yml
+++ b/.github/workflows/pr-conventional-commit.yml
@@ -27,6 +27,7 @@ jobs:
             claude-core
             claude-respond
             claude-engineer
+            claude-agent
             claude-report
             docs
             workflows

--- a/claude-engineer/agents/code-janitor.md
+++ b/claude-engineer/agents/code-janitor.md
@@ -30,3 +30,9 @@ Add `maintenance` alongside the task label when creating work items.
 4. **Don't re-scan everything.** Check your dashboard for areas already reviewed. Focus on new or changed areas.
 5. **Prioritize high-impact cleanup.** Large dead files > small unused variables. Widely duplicated patterns > one-off copies.
 6. **Be conservative.** Only flag code as dead if you can confirm it has no callers. Exported/public APIs may be used by external consumers — note uncertainty in findings.
+
+## Issue Creation Rules
+
+- **Group related findings into a single issue.** If multiple findings affect the same directory or would be fixed in the same PR, create ONE issue covering all of them. For example, "Makefile doesn't use shared pattern" and "requirements-test.txt duplicates root file" in the same directory are one issue, not two.
+- **Before creating an issue, review your other findings from this run.** If you've already planned an issue for the same area, add the new finding to that issue instead.
+- **Check open issues AND open PRs.** A finding may already be addressed by a PR that hasn't merged yet. Search both before creating.


### PR DESCRIPTION
## Summary

- **code-janitor agent:** Add explicit rules to group related findings into a single issue when they affect the same directory or would be fixed in the same PR. This prevents duplicate issues like #72/#73.
- **pr-conventional-commit.yml:** Add missing `claude-agent` scope that was never added when the `claude-agent/` action was created. Fixes `check-title` failures on PRs #74 and #76.

## Root Cause

The code-janitor found two symptoms of the same problem (claude-agent/ wasn't consolidated during Makefile.common migration) and created two separate issues 10 seconds apart. The dedup check only matched exact titles, so semantically identical issues slipped through.

## Test plan

- [ ] CI passes (check-title, test, validate-workflows)
- [ ] After merge, close PR #76 and issue #73 as duplicates of PR #74 / issue #72
- [ ] Re-run janitor to verify it doesn't create duplicate issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)