### PR TITLE
fix(workflows): install gh CLI on self-hosted runner and add URL encoding guidance

### DIFF
--- a/.github/workflows/claude-engineers.yml
+++ b/.github/workflows/claude-engineers.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Install gh CLI
+        uses: dev-hanz-ops/install-gh-cli-action@5f980e3264dca4ea5ddb9bf2e2a654e2ea6a0f94 # v0.2.1
+
       - name: Run Documentation Engineer
         uses: ./claude-engineer
         with:
@@ -41,6 +44,9 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install gh CLI
+        uses: dev-hanz-ops/install-gh-cli-action@5f980e3264dca4ea5ddb9bf2e2a654e2ea6a0f94 # v0.2.1
 
       - name: Run Code Janitor
         uses: ./claude-engineer

--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -108,6 +108,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Install gh CLI
+        uses: dev-hanz-ops/install-gh-cli-action@5f980e3264dca4ea5ddb9bf2e2a654e2ea6a0f94 # v0.2.1
+
       - name: Run Claude
         uses: ./claude-respond
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ Engineer agents operate autonomously with dashboard management:
 ### CI/Runner Environment
 
 - **Self-hosted runner:** `diranged-claude-code`
-- **`gh` CLI may NOT be installed** — agents use curl fallback with `GITHUB_TOKEN`
+- **`gh` CLI is installed** via `dev-hanz-ops/install-gh-cli-action` in workflow steps
 - **`make` may not be installed** — agents use direct venv+unittest fallback
 - **GitHub token lacks `workflows` permission** — cannot push workflow files directly
 

--- a/claude-core/instructions/10-github.md
+++ b/claude-core/instructions/10-github.md
@@ -7,9 +7,25 @@
 
 ## GitHub API Access
 
-- The `gh` CLI may or may not be installed. **Try `gh` first** — if it fails with "command not found", immediately switch to `curl` with `Authorization: Bearer $GITHUB_TOKEN` headers. Do not spend turns searching for the binary.
-- Example curl fallback: `curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER"`
+- The `gh` CLI is installed and available. **Always prefer `gh`** for GitHub API interactions — it handles authentication, pagination, and URL encoding automatically.
+- If `gh` fails with "command not found", fall back to `curl` with `Authorization: Bearer $GITHUB_TOKEN` headers.
 - **Never print or log token values.** If you need to verify a token exists, use `echo "TOKEN_SET: ${GITHUB_TOKEN:+yes}"` — never echo the actual value.
+
+### URL Encoding in curl
+
+When using `curl` with the GitHub API, **you must URL-encode special characters** in query parameters:
+
+- Colons (`:`) → `%3A` — this is critical for labels like `claude-engineer:docs`
+- Spaces → `%20` or `+`
+- Other special characters: `@` → `%40`, `#` → `%23`
+
+**Wrong:** `curl ... "https://api.github.com/repos/$GITHUB_REPOSITORY/issues?labels=claude-engineer:docs"`
+**Right:** `curl ... "https://api.github.com/repos/$GITHUB_REPOSITORY/issues?labels=claude-engineer%3Adocs"`
+
+With `gh`, this is handled automatically:
+```bash
+gh issue list --repo "$GITHUB_REPOSITORY" --label "claude-engineer:docs" --state open --json number,title
+```
 
 ## Comment Management
 


### PR DESCRIPTION
## Summary

- Adds `dev-hanz-ops/install-gh-cli-action` step to all jobs running on `diranged-claude-code` self-hosted runner (`claude-engineers.yml` and `claude-issue.yml`)
- Updates `claude-core/instructions/10-github.md` to tell agents `gh` is available, prefer it, and document URL encoding rules for curl fallback (`:` → `%3A`)
- Updates `CLAUDE.md` to reflect that `gh` is now installed

## Context

From [run 22733170304](https://github.com/diranged/claude-code-agentic-workflows/actions/runs/22733170304), both engineer agents wasted turns:
1. Trying `gh` → `command not found` (1 turn each)
2. Using curl with unencoded colons in labels → 404s (2-3 turns each)

## Test plan

- [ ] Trigger `Claude Engineers` workflow dispatch and verify both agents use `gh` successfully on first attempt
- [ ] Verify no 404s from unencoded label colons in curl fallback paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)