### PR TITLE
fix(workflows): correct install-gh-cli-action pinned SHA

### DIFF
--- a/.github/workflows/claude-engineers.yml
+++ b/.github/workflows/claude-engineers.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install gh CLI
-        uses: dev-hanz-ops/install-gh-cli-action@5f980e3264dca4ea5ddb9bf2e2a654e2ea6a0f94 # v0.2.1
+        uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
 
       - name: Run Documentation Engineer
         uses: ./claude-engineer
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install gh CLI
-        uses: dev-hanz-ops/install-gh-cli-action@5f980e3264dca4ea5ddb9bf2e2a654e2ea6a0f94 # v0.2.1
+        uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
 
       - name: Run Code Janitor
         uses: ./claude-engineer

--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install gh CLI
-        uses: dev-hanz-ops/install-gh-cli-action@5f980e3264dca4ea5ddb9bf2e2a654e2ea6a0f94 # v0.2.1
+        uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
 
       - name: Run Claude
         uses: ./claude-respond


### PR DESCRIPTION
## Summary

- Fixes incorrect pinned SHA for `dev-hanz-ops/install-gh-cli-action` that caused jobs to fail with "action could not be found"
- Previous SHA `5f980e3...` was invalid; correct SHA for v0.2.1 is `af38ce09b...`

## Context

Follow-up to #84. The run [22742890423](https://github.com/diranged/claude-code-agentic-workflows/actions/runs/22742890423) failed immediately because the action SHA didn't resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)