### PR TITLE
fix(workflows): pin gh CLI to v2.87.3 to fix Projects Classic deprecation error

### DIFF
--- a/.github/workflows/claude-engineers.yml
+++ b/.github/workflows/claude-engineers.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Install gh CLI
         uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
+        with:
+          gh-cli-version: 2.87.3
 
       - name: Run Documentation Engineer
         uses: ./claude-engineer
@@ -47,6 +49,8 @@ jobs:
 
       - name: Install gh CLI
         uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
+        with:
+          gh-cli-version: 2.87.3
 
       - name: Run Code Janitor
         uses: ./claude-engineer

--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -110,6 +110,8 @@ jobs:
 
       - name: Install gh CLI
         uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
+        with:
+          gh-cli-version: 2.87.3
 
       - name: Run Claude
         uses: ./claude-respond


### PR DESCRIPTION
## Summary

- Pins `install-gh-cli-action` to gh CLI v2.87.3 (latest) instead of the default v2.14.2
- Fixes `gh issue view --comments` failing with exit code 1 due to deprecated Projects Classic GraphQL query

## Context

Follow-up to #85. Run [22743189876](https://github.com/diranged/claude-code-agentic-workflows/actions/runs/22743189876) showed docs-engineer hitting a hard failure on `gh issue view 51 --comments` because gh 2.14.2 queries the deprecated `projectCards` GraphQL field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)