### PR TITLE
feat(agents): add claude:auto_advance label for pipeline gating

### DIFF
--- a/claude-core/agents/agentic-designer.md
+++ b/claude-core/agents/agentic-designer.md
@@ -34,7 +34,13 @@ Always include the workflow run link in your tracking comment so reviewers can i
 
 ## Advancing the Pipeline
 
-After posting your design, advance the issue to architecture review:
+After posting your design, check whether the issue has the `claude:auto_advance` label:
+
+```bash
+gh issue view $ISSUE_NUMBER --repo "$GITHUB_REPOSITORY" --json labels --jq '.labels[].name' | grep -q '^claude:auto_advance$'
+```
+
+### If `claude:auto_advance` IS present (automated pipeline):
 
 1. Remove the `claude:design` label (if present):
    ```bash
@@ -44,14 +50,22 @@ After posting your design, advance the issue to architecture review:
    ```bash
    gh issue edit $ISSUE_NUMBER --repo "$GITHUB_REPOSITORY" --add-label "claude:review"
    ```
+3. End the design with:
+   > Design posted. Auto-advancing to architecture review.
 
-This hands the issue to the architect agent for design review before implementation.
+### If `claude:auto_advance` is NOT present (human-gated pipeline):
 
-## Footer
-
-End the design with:
-
-> Design posted. Advancing to architecture review.
+1. Remove the `claude:design` label (if present):
+   ```bash
+   gh issue edit $ISSUE_NUMBER --repo "$GITHUB_REPOSITORY" --remove-label "claude:design"
+   ```
+2. Do **not** apply any pipeline labels.
+3. Set the status to "Needs Input" and assign notify owners per the GitHub Environment instructions.
+4. End the design with:
+   > Design posted. Waiting for human review.
+   >
+   > To advance to architecture review, apply the `claude:review` label.
+   > To skip review and go straight to implementation, apply the `claude:implement` label.
 
 ## Constraints
 

--- a/claude-core/agents/architect.md
+++ b/claude-core/agents/architect.md
@@ -55,7 +55,13 @@ Always include the workflow run link in your tracking comment. The run URL is pr
 
 ## Advancing the Pipeline
 
-After completing your review, decide the next step based on your findings:
+After completing your review, first check whether the issue has the `claude:auto_advance` label:
+
+```bash
+gh issue view $ISSUE_NUMBER --repo "$GITHUB_REPOSITORY" --json labels --jq '.labels[].name' | grep -q '^claude:auto_advance$'
+```
+
+Then decide the next step based on your findings AND whether auto-advance is enabled:
 
 ### If the design is sound (no critical issues):
 
@@ -63,14 +69,22 @@ After completing your review, decide the next step based on your findings:
    ```bash
    gh issue edit $ISSUE_NUMBER --repo "$GITHUB_REPOSITORY" --remove-label "claude:review"
    ```
-2. Apply the `claude:implement` label to trigger the developer:
+
+2. **If `claude:auto_advance` IS present**, apply the `claude:implement` label to trigger the developer:
    ```bash
    gh issue edit $ISSUE_NUMBER --repo "$GITHUB_REPOSITORY" --add-label "claude:implement"
    ```
-3. End your report with:
-   > Design approved. Advancing to implementation.
+   End your report with:
+   > Design approved. Auto-advancing to implementation.
+
+3. **If `claude:auto_advance` is NOT present**, do **not** apply any pipeline labels. Set the status to "Needs Input" and assign notify owners per the GitHub Environment instructions. End your report with:
+   > Design approved. Waiting for human to advance.
+   >
+   > To proceed with implementation, apply the `claude:implement` label.
 
 ### If the design needs rework (critical issues found):
+
+Rework always goes back to the designer regardless of auto-advance:
 
 1. Remove the `claude:review` label:
    ```bash

--- a/claude-engineer/instructions/00-engineer-base.md
+++ b/claude-engineer/instructions/00-engineer-base.md
@@ -83,6 +83,7 @@ If no open issue exists, create one:
 gh label create "<dashboard_label>" --repo "$GITHUB_REPOSITORY" --description "Engineer dashboard" --color "0075ca" 2>/dev/null || true
 gh label create "<task_label>" --repo "$GITHUB_REPOSITORY" --description "Work item from engineer" --color "c5def5" 2>/dev/null || true
 gh label create "<delegation_label>" --repo "$GITHUB_REPOSITORY" --description "Trigger Claude design pipeline" --color "5319e7" 2>/dev/null || true
+gh label create "claude:auto_advance" --repo "$GITHUB_REPOSITORY" --description "Auto-advance through design/review/implement pipeline" --color "bfd4f2" 2>/dev/null || true
 
 # Create dashboard
 gh issue create --repo "$GITHUB_REPOSITORY" \
@@ -168,11 +169,11 @@ By the time you create an issue, Phase 3 has already confirmed the finding is ne
 
 1. **Create a focused issue** with a clear title and description including file paths and line references where relevant.
 
-2. **Delegate to the design pipeline** by adding the delegation label:
+2. **Delegate to the design pipeline** by adding the delegation label and the `claude:auto_advance` label:
    ```bash
-   gh issue edit <NUMBER> --repo "$GITHUB_REPOSITORY" --add-label "<delegation_label>"
+   gh issue edit <NUMBER> --repo "$GITHUB_REPOSITORY" --add-label "<delegation_label>" --add-label "claude:auto_advance"
    ```
-   This triggers the design → review → implement pipeline.
+   The `claude:auto_advance` label tells the pipeline to proceed through design → review → implement without waiting for human approval at each stage. Issues created by engineer agents are trusted to run autonomously.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

- Add `claude:auto_advance` label that controls whether the design→review→implement pipeline runs autonomously or pauses for human approval
- **With label**: Pipeline auto-advances (current behavior) — used by engineer managers
- **Without label**: Pipeline pauses after design and after review, waiting for human to apply the next label

## Changes

- **`agentic-designer.md`**: Check for `claude:auto_advance` before applying `claude:review`. Without it, pause and ask human to review.
- **`architect.md`**: Check for `claude:auto_advance` before applying `claude:implement`. Without it, pause and inform human design is approved.
- **`00-engineer-base.md`**: Engineer managers apply `claude:auto_advance` alongside the delegation label when creating issues. Also ensure the label is created during dashboard setup.

## Motivation

Issue #89 demonstrated the problem: a human-created issue went through the entire design→review→implement pipeline in 5 minutes with zero human input. The designer auto-triggered the architect, which auto-triggered the developer, which opened a PR — all before the human could review the design.

## Test plan

- [ ] Create an issue manually, comment `@claude` — verify pipeline pauses after design
- [ ] Apply `claude:review` manually — verify architect pauses after review
- [ ] Apply `claude:implement` manually — verify developer runs
- [ ] Create an issue with `claude:auto_advance` label — verify full auto pipeline
- [ ] Verify engineer managers still apply `claude:auto_advance` when delegating

🤖 Generated with [Claude Code](https://claude.com/claude-code)