### PR TITLE
fix(claude-core): install gh CLI automatically and remove curl fallback

### DIFF
--- a/.github/workflows/repo-engineer-managers.yml
+++ b/.github/workflows/repo-engineer-managers.yml
@@ -21,11 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Install gh CLI
-        uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
-        with:
-          gh-cli-version: 2.87.3
-
       - name: Run Documentation Engineer
         uses: ./claude-engineer
         with:
@@ -46,11 +41,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Install gh CLI
-        uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
-        with:
-          gh-cli-version: 2.87.3
 
       - name: Run Code Janitor
         uses: ./claude-engineer

--- a/.github/workflows/shared-claude-engineers.yml
+++ b/.github/workflows/shared-claude-engineers.yml
@@ -174,12 +174,6 @@ on:
         type: string
         default: "rocket"
 
-      # Infrastructure
-      gh_cli_version:
-        description: "Version of gh CLI to install on the runner"
-        type: string
-        default: "2.87.3"
-
     secrets:
       claude_code_oauth_token:
         description: "Claude Code OAuth token (subscription billing)"
@@ -276,11 +270,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Install gh CLI
-        uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
-        with:
-          gh-cli-version: ${{ inputs.gh_cli_version }}
 
       - name: Run Claude
         uses: diranged/claude-code-agentic-workflows/claude-respond@main

--- a/.github/workflows/shared-claude-responder.yml
+++ b/.github/workflows/shared-claude-responder.yml
@@ -134,12 +134,6 @@ on:
         type: string
         default: "rocket"
 
-      # Infrastructure
-      gh_cli_version:
-        description: "Version of gh CLI to install on the runner"
-        type: string
-        default: "2.87.3"
-
     secrets:
       claude_code_oauth_token:
         description: "Claude Code OAuth token (subscription billing)"
@@ -216,11 +210,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Install gh CLI
-        uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
-        with:
-          gh-cli-version: ${{ inputs.gh_cli_version }}
 
       - name: Run Claude
         uses: diranged/claude-code-agentic-workflows/claude-respond@main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ Engineer agents operate autonomously with dashboard management:
 ### CI/Runner Environment
 
 - **Self-hosted runner:** `diranged-claude-code`
-- **`gh` CLI is installed** via `dev-hanz-ops/install-gh-cli-action` in workflow steps
+- **`gh` CLI is installed** automatically by `claude-core` via `dev-hanz-ops/install-gh-cli-action`
 - **`make` may not be installed** — agents use direct venv+unittest fallback
 - **GitHub token lacks `workflows` permission** — cannot push workflow files directly
 

--- a/claude-core/action.yml
+++ b/claude-core/action.yml
@@ -118,6 +118,10 @@ outputs:
 runs:
   using: "composite"
   steps:
+    # Step 0: Ensure gh CLI is available
+    - name: Install gh CLI
+      uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
+
     # Step 1: Validate all inputs
     - name: Validate Inputs
       shell: bash

--- a/claude-core/instructions/10-github.md
+++ b/claude-core/instructions/10-github.md
@@ -7,32 +7,16 @@
 
 ## GitHub API Access
 
-- The `gh` CLI is installed and available. **Always prefer `gh`** for GitHub API interactions — it handles authentication, pagination, and URL encoding automatically.
-- If `gh` fails with "command not found", fall back to `curl` with `Authorization: Bearer $GITHUB_TOKEN` headers.
+- The `gh` CLI is installed and authenticated. **Always use `gh`** for GitHub API interactions — it handles authentication, pagination, and URL encoding automatically.
+- **Do not fall back to `curl`.** If `gh` fails, report the error — do not attempt workarounds.
 - **Never print or log token values.** If you need to verify a token exists, use `echo "TOKEN_SET: ${GITHUB_TOKEN:+yes}"` — never echo the actual value.
-
-### URL Encoding in curl
-
-When using `curl` with the GitHub API, **you must URL-encode special characters** in query parameters:
-
-- Colons (`:`) → `%3A` — this is critical for labels like `claude-engineer:docs`
-- Spaces → `%20` or `+`
-- Other special characters: `@` → `%40`, `#` → `%23`
-
-**Wrong:** `curl ... "https://api.github.com/repos/$GITHUB_REPOSITORY/issues?labels=claude-engineer:docs"`
-**Right:** `curl ... "https://api.github.com/repos/$GITHUB_REPOSITORY/issues?labels=claude-engineer%3Adocs"`
-
-With `gh`, this is handled automatically:
-```bash
-gh issue list --repo "$GITHUB_REPOSITORY" --label "claude-engineer:docs" --state open --json number,title
-```
 
 ## Comment Management
 
 - A **tracking comment** has been created on the issue for you to post progress updates.
 - **Never create new top-level comments** on the issue — always update the existing tracking comment.
 - The tracking comment ID is provided in the runtime context below.
-- Use `gh api` (or curl) with PATCH to update the comment body.
+- Use `gh api` with PATCH to update the comment body.
 
 ## Workflow Run Links
 


### PR DESCRIPTION
## Summary

- **`claude-core` now installs `gh` CLI as its first step**, ensuring it's always available regardless of runner environment
- **Removed curl fallback instruction** from `10-github.md` — agents now fail loudly if `gh` is unavailable instead of silently degrading
- **Removed redundant `Install gh CLI` steps** from all shared workflows and `repo-engineer-managers.yml` since `claude-core` handles it

## Motivation

A Sproutbook engineer agent ran on a self-hosted runner without `gh` installed. Instead of failing, Claude silently fell back to `curl` (which also failed), then gave up on API access entirely and ran a useless local-only scan. The job reported `success` despite never creating a dashboard or checking existing issues.

## Changes

- `claude-core/action.yml` — new "Install gh CLI" step before input validation
- `claude-core/instructions/10-github.md` — replaced curl fallback guidance with "do not fall back, report the error"
- `shared-claude-responder.yml` — removed `Install gh CLI` step and `gh_cli_version` input
- `shared-claude-engineers.yml` — removed `Install gh CLI` step and `gh_cli_version` input
- `repo-engineer-managers.yml` — removed `Install gh CLI` steps from both jobs
- `CLAUDE.md` — updated docs to reflect automatic installation

## Test plan

- [ ] Run on a self-hosted runner without `gh` pre-installed — verify `claude-core` installs it
- [ ] Verify engineer agents can create dashboards and interact with GitHub API
- [ ] Verify shared workflows still work without the `gh_cli_version` input

🤖 Generated with [Claude Code](https://claude.com/claude-code)