### PR TITLE
feat(workflows): add implementation concurrency control

### DIFF
--- a/.github/workflows/repo-claude-engineers.yml
+++ b/.github/workflows/repo-claude-engineers.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       runner: diranged-claude-code
       notify_owners: "diranged"
+      max_implementations: "2"
       allowed_tools: "Bash(*),Read,Glob,Grep,Edit,Write,WebFetch,WebSearch"
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}

--- a/.github/workflows/shared-claude-engineers.yml
+++ b/.github/workflows/shared-claude-engineers.yml
@@ -82,6 +82,12 @@ on:
         type: string
         default: "claude-opus-4-20250514"
 
+      # Concurrency control
+      max_implementations:
+        description: "Maximum concurrent implementations (issues with implement label + open Claude PRs). 0 = unlimited."
+        type: string
+        default: "0"
+
       # CI retry configuration
       ci_retry:
         description: "Enable CI retry mode (set to 'true' when called from workflow_run)"
@@ -227,11 +233,90 @@ jobs:
           esac
         shell: bash
 
-  # Job 2: Create a tracking comment
-  setup:
+  # Job 2: Check implementation concurrency before running the developer
+  concurrency-gate:
     runs-on: ubuntu-latest
     needs: detect-intent
     if: inputs.ci_retry != 'true'
+    permissions:
+      issues: write
+      pull-requests: read
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+    steps:
+      - name: Check implementation concurrency
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAX_IMPL: ${{ inputs.max_implementations }}
+          LABEL_PREFIX: ${{ inputs.label_prefix }}
+          ISSUE_NUMBER: ${{ needs.detect-intent.outputs.issue_number }}
+          DETECTED_AGENT: ${{ needs.detect-intent.outputs.agent }}
+        run: |
+          # Only gate implement agents; design and review always proceed
+          if [ "$DETECTED_AGENT" != "${{ inputs.implement_agent }}" ]; then
+            echo "Not an implementation run — skipping concurrency check"
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 0 means unlimited
+          if [ "$MAX_IMPL" = "0" ]; then
+            echo "No concurrency limit set"
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Count issues with the implement label (excluding this one, since the label was just applied)
+          IMPL_ISSUES=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "${LABEL_PREFIX}:implement" \
+            --state open \
+            --json number \
+            --jq "[.[] | select(.number != ${ISSUE_NUMBER})] | length")
+
+          # Count open PRs authored by Claude bots
+          CLAUDE_PRS=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --json number,author \
+            --jq '[.[] | select(.author.login | test("claude|\\[bot\\]"))] | length')
+
+          TOTAL=$((IMPL_ISSUES + CLAUDE_PRS))
+          echo "Implementation slots: ${TOTAL}/${MAX_IMPL} in use (${IMPL_ISSUES} implementing + ${CLAUDE_PRS} open PRs)"
+
+          if [ "$TOTAL" -ge "$MAX_IMPL" ]; then
+            echo "Concurrency limit reached — queuing implementation"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+
+            # Remove the implement label so it can be re-applied later
+            gh issue edit "$ISSUE_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --remove-label "${LABEL_PREFIX}:implement"
+
+            # Add a queued label
+            gh label create "${LABEL_PREFIX}:queued" \
+              --repo "${{ github.repository }}" \
+              --description "Implementation approved but waiting for a slot" \
+              --color "fbca04" 2>/dev/null || true
+            gh issue edit "$ISSUE_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --add-label "${LABEL_PREFIX}:queued"
+
+            # Post a comment explaining why
+            gh issue comment "$ISSUE_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --body "Implementation queued — ${TOTAL}/${MAX_IMPL} slots in use. Will be picked up when a slot opens."
+          else
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+  # Job 3: Create a tracking comment
+  setup:
+    runs-on: ubuntu-latest
+    needs: [detect-intent, concurrency-gate]
+    if: inputs.ci_retry != 'true' && needs.concurrency-gate.outputs.allowed == 'true'
     permissions:
       issues: write
       pull-requests: write
@@ -258,11 +343,11 @@ jobs:
           echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
         shell: bash
 
-  # Job 3: Run Claude with the routed agent
+  # Job 4: Run Claude with the routed agent
   claude-run:
     runs-on: ${{ inputs.runner }}
-    needs: [detect-intent, setup]
-    if: inputs.ci_retry != 'true'
+    needs: [detect-intent, concurrency-gate, setup]
+    if: inputs.ci_retry != 'true' && needs.concurrency-gate.outputs.allowed == 'true'
     permissions:
       contents: write
       issues: write
@@ -297,8 +382,12 @@ jobs:
           display_report: ${{ inputs.display_report }}
           dry_run: ${{ inputs.dry_run }}
           issue_comment_id: ${{ needs.setup.outputs.comment_id }}
+          prompt: |
+            ## Concurrency Configuration
+            - Max concurrent implementations: ${{ inputs.max_implementations }} (0 = unlimited)
+            - Label prefix: ${{ inputs.label_prefix }}
 
-  # Job 4: CI retry — re-trigger developer when CI fails on a Claude-authored PR
+  # Job 5: CI retry — re-trigger developer when CI fails on a Claude-authored PR
   ci-retry:
     runs-on: ubuntu-latest
     if: inputs.ci_retry == 'true'

--- a/claude-core/agents/architect.md
+++ b/claude-core/agents/architect.md
@@ -13,7 +13,7 @@ You are operating as an **architecture review agent**. Your job is to evaluate t
 
 ## Workflow
 
-1. **Read the issue** — use `gh issue view $ISSUE_NUMBER --comments` (or curl fallback per the GitHub instructions) to understand the scope and any specific architectural concerns.
+1. **Read the issue** — use `gh issue view $ISSUE_NUMBER --comments` to understand the scope and any specific architectural concerns.
 2. **Explore the architecture** — map out the module structure, dependency graph, and key abstractions. Focus on boundaries between components.
 3. **Categorize findings** — group by severity and architectural concern.
 4. **Post findings** — update the tracking comment with your structured report.
@@ -70,12 +70,30 @@ Then decide the next step based on your findings AND whether auto-advance is ena
    gh issue edit $ISSUE_NUMBER --repo "$GITHUB_REPOSITORY" --remove-label "claude:review"
    ```
 
-2. **If `claude:auto_advance` IS present**, apply the `claude:implement` label to trigger the developer:
+2. **If `claude:auto_advance` IS present**, check implementation concurrency before advancing:
+
+   ```bash
+   # Check the Concurrency Configuration in the Task Context for the max limit
+   # If max is 0 or not set, skip this check (unlimited)
+   IMPL_COUNT=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "claude:implement" --state open --json number --jq 'length')
+   PR_COUNT=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,author --jq '[.[] | select(.author.login | test("claude|\\[bot\\]"))] | length')
+   TOTAL=$((IMPL_COUNT + PR_COUNT))
+   ```
+
+   **If under the limit (or limit is 0)**, apply the `claude:implement` label:
    ```bash
    gh issue edit $ISSUE_NUMBER --repo "$GITHUB_REPOSITORY" --add-label "claude:implement"
    ```
    End your report with:
    > Design approved. Auto-advancing to implementation.
+
+   **If at or over the limit**, do **not** apply `claude:implement`. Instead, add the `claude:queued` label:
+   ```bash
+   gh label create "claude:queued" --repo "$GITHUB_REPOSITORY" --description "Implementation approved but waiting for a slot" --color "fbca04" 2>/dev/null || true
+   gh issue edit $ISSUE_NUMBER --repo "$GITHUB_REPOSITORY" --add-label "claude:queued"
+   ```
+   End your report with:
+   > Design approved. Implementation queued — {TOTAL}/{MAX} slots in use. Will be picked up when a slot opens.
 
 3. **If `claude:auto_advance` is NOT present**, do **not** apply any pipeline labels. Set the status to "Needs Input" and assign notify owners per the GitHub Environment instructions. End your report with:
    > Design approved. Waiting for human to advance.


### PR DESCRIPTION
## Summary

- Add `max_implementations` input to `shared-claude-engineers.yml` (default 0 = unlimited)
- **Hard gate at workflow level**: new `concurrency-gate` job counts issues with `claude:implement` label + open Claude PRs before running the developer agent
- **Soft gate at architect level**: architect checks concurrency before applying `claude:implement` when auto-advancing
- Over-limit issues get `claude:queued` label and a comment explaining they'll be picked up when a slot opens

## How it works

```yaml
# Consumer's workflow
uses: .../shared-claude-engineers.yml@v0
with:
  runner: my-runner
  max_implementations: "2"   # Never more than 2 concurrent implementations
```

When the 3rd implementation is triggered:
1. Workflow gate removes `claude:implement`, adds `claude:queued`
2. Posts comment: "Implementation queued — 2/2 slots in use"
3. Developer agent never launches

## What counts toward the limit

- Open issues with `claude:implement` label (excluding the current one)
- Open PRs authored by Claude bots

## Test plan

- [ ] Trigger implementation with `max_implementations: "1"` and 0 existing — should proceed
- [ ] Trigger implementation with `max_implementations: "1"` and 1 existing — should queue
- [ ] Verify `claude:queued` label is created and applied
- [ ] Verify design and review agents are not affected by the gate
- [ ] Verify `max_implementations: "0"` (default) means unlimited

🤖 Generated with [Claude Code](https://claude.com/claude-code)