### PR TITLE
fix(workflows): default allowed_bots to claude[bot] to fix pipeline bot rejection

### DIFF
--- a/.github/workflows/shared-claude-engineers.yml
+++ b/.github/workflows/shared-claude-engineers.yml
@@ -106,7 +106,7 @@ on:
       allowed_bots:
         description: "Comma-separated bot usernames allowed to trigger, or '*' for all"
         type: string
-        default: ""
+        default: "claude[bot]"
 
       # Notification
       notify_owners:

--- a/.github/workflows/shared-claude-responder.yml
+++ b/.github/workflows/shared-claude-responder.yml
@@ -52,7 +52,7 @@ on:
       allowed_bots:
         description: "Comma-separated bot usernames allowed to trigger, or '*' for all"
         type: string
-        default: ""
+        default: "claude[bot]"
 
       # Notification
       notify_owners:


### PR DESCRIPTION
## Summary

- Default `allowed_bots` to `claude[bot]` in both shared reusable workflows (`shared-claude-engineers.yml` and `shared-claude-responder.yml`)
- Fixes the pipeline bot rejection error where Claude agents advancing the pipeline (e.g., applying `claude:implement` after review) are rejected with "non-human actor" error

## Root Cause Analysis

**Bot rejection (run [22811548948](https://github.com/diranged/claude-code-agentic-workflows/actions/runs/22811548948/job/66169312223)):**
When a Claude agent applies a label to advance the pipeline, the `issues.labeled` event is attributed to `claude[bot]` (the Claude Code GitHub App). The upstream `claude-code-action` rejects Bot actors unless `allowed_bots` is configured, breaking the design→review→implement flow.

**startup_failure (issue #97):**
The Sproutbook `startup_failure` runs were caused by a timing mismatch — the consuming repo passed `max_implementations: "2"` before PR #98 added that input to our shared workflow. GitHub rejects undefined inputs at startup. This is now resolved since PR #98 is merged.

## Changes

| File | Change |
|------|--------|
| `shared-claude-engineers.yml` | Default `allowed_bots` to `claude[bot]` |
| `shared-claude-responder.yml` | Default `allowed_bots` to `claude[bot]` |

## Test plan

- [x] All existing tests pass (`make test`)
- [ ] Verify pipeline auto-advance works: apply `claude:design` label → designer runs → applies `claude:review` → reviewer runs (no bot rejection)
- [ ] Verify Sproutbook workflows no longer get `startup_failure`

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)