### PR TITLE
fix(workflows): document required caller permissions for shared workflows

### DIFF
--- a/.github/workflows/shared-claude-engineers.yml
+++ b/.github/workflows/shared-claude-engineers.yml
@@ -3,6 +3,9 @@ name: "Shared: Claude Engineers"
 # Reusable workflow for handling claude:* label triggers on issues.
 # Implements the design -> implement -> CI-retry lifecycle.
 #
+# Required caller permissions (must be granted by the calling job):
+#   contents: write, issues: write, pull-requests: write, id-token: write
+#
 # Example caller:
 #   on:
 #     issues:
@@ -17,6 +20,11 @@ name: "Shared: Claude Engineers"
 #         && github.event.action == 'labeled'
 #         && !github.event.issue.pull_request
 #         && startsWith(github.event.label.name, 'claude:')
+#       permissions:
+#         contents: write
+#         issues: write
+#         pull-requests: write
+#         id-token: write
 #       uses: diranged/claude-code-agentic-workflows/.github/workflows/shared-claude-engineers.yml@v0
 #       with:
 #         runner: my-self-hosted-runner
@@ -27,6 +35,11 @@ name: "Shared: Claude Engineers"
 #       if: >-
 #         github.event_name == 'workflow_run'
 #         && github.event.workflow_run.conclusion == 'failure'
+#       permissions:
+#         contents: write
+#         issues: write
+#         pull-requests: write
+#         id-token: write
 #       uses: diranged/claude-code-agentic-workflows/.github/workflows/shared-claude-engineers.yml@v0
 #       with:
 #         runner: my-self-hosted-runner

--- a/.github/workflows/shared-claude-responder.yml
+++ b/.github/workflows/shared-claude-responder.yml
@@ -3,6 +3,9 @@ name: "Shared: Claude Responder"
 # Reusable workflow for handling @claude mentions in issues and PRs.
 # Consumers call this from their own workflow that defines the trigger events.
 #
+# Required caller permissions (must be granted by the calling job):
+#   contents: write, issues: write, pull-requests: write, id-token: write
+#
 # Example caller:
 #   on:
 #     issue_comment:
@@ -21,6 +24,11 @@ name: "Shared: Claude Responder"
 #           && github.event.sender.type != 'Bot'
 #           && contains(github.event.comment.body, '@claude'))
 #         || (github.event_name == 'issues' && github.event.action == 'assigned')
+#       permissions:
+#         contents: write
+#         issues: write
+#         pull-requests: write
+#         id-token: write
 #       uses: diranged/claude-code-agentic-workflows/.github/workflows/shared-claude-responder.yml@v0
 #       with:
 #         runner: my-self-hosted-runner


### PR DESCRIPTION
## Summary

- Add required permissions documentation to both shared reusable workflow headers
- Add `permissions:` blocks to example caller jobs

## Root Cause

The actual root cause of issue #97's `startup_failure` is **restrictive default workflow permissions** on the calling repository. Sproutbook has `default_workflow_permissions: read`, but our reusable workflows' jobs request `write` permissions for issues, pull-requests, contents, and id-token.

When a reusable workflow's permission requests exceed what the caller grants, GitHub fails the entire run with `startup_failure` before any jobs execute — with no error message in the API.

The fix is on the **caller side**: each job calling a shared workflow must include a `permissions:` block granting the necessary permissions.

## Verification

```bash
# Sproutbook's restrictive setting:
gh api repos/Sproutbook/sproutbook-backend-amplify/actions/permissions/workflow
# {"can_approve_pull_request_reviews":false,"default_workflow_permissions":"read"}
```

## Test plan

- [x] All existing tests pass
- [ ] After updating Sproutbook's caller workflows with `permissions:` blocks, verify the `startup_failure` is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)