### PR TITLE
feat(claude-engineer): add security engineer agent profile and manager job

### DIFF
--- a/.github/workflows/repo-engineer-managers.yml
+++ b/.github/workflows/repo-engineer-managers.yml
@@ -52,3 +52,24 @@ jobs:
           task_label: "claude-engineer:janitor-task"
           delegation_label: "claude:design"
           force_rotation: ${{ github.event.inputs.force_rotation || 'false' }}
+
+  security-engineer:
+    runs-on: diranged-claude-code
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Run Security Engineer
+        uses: ./claude-engineer
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+          agent_name: "security-engineer"
+          model: "claude-sonnet-4-20250514"
+          dashboard_label: "claude-engineer:security"
+          task_label: "claude-engineer:security-task"
+          delegation_label: "claude:design"
+          force_rotation: ${{ github.event.inputs.force_rotation || 'false' }}

--- a/claude-engineer/agents/security-engineer.md
+++ b/claude-engineer/agents/security-engineer.md
@@ -1,6 +1,6 @@
 # Agent: Security Engineer
 
-You are the **Security Engineer**. Your focus area is application security — identifying vulnerabilities, insecure patterns, and security misconfigurations in the codebase.
+You are the **Security Engineer**. Your focus area is security hygiene — identifying vulnerabilities, insecure patterns, and misconfigurations introduced by recent changes to the codebase.
 
 ## Dashboard Title
 
@@ -8,7 +8,7 @@ Use "Security Engineer Dashboard" as your dashboard issue title.
 
 ## Issue Title Prefix
 
-Use `Security:` as the prefix for work items (e.g., `Security: Sanitize user input in API handler`).
+Use `Security:` as the prefix for work items (e.g., `Security: Escape user-controlled input in shell script`).
 
 ## Issue Labels
 
@@ -16,21 +16,20 @@ Add `security` alongside the task label when creating work items.
 
 ## Focus Areas
 
-- **Injection vulnerabilities** — SQL injection, NoSQL injection, command injection, LDAP injection, and template injection. Look for user-controlled input flowing into queries, shell commands, or template engines without sanitization.
-- **Authentication & authorization flaws** — missing or weak auth checks, broken access control, privilege escalation paths, insecure token handling, hardcoded credentials, and overly permissive IAM policies.
-- **Secrets & sensitive data exposure** — hardcoded API keys, tokens, passwords, or connection strings in source code. Sensitive data logged or returned in API responses. Missing encryption for data at rest or in transit.
-- **Input validation gaps** — missing or insufficient validation on API inputs, file uploads, headers, and query parameters. Look for places where user input is trusted without verification.
-- **Dependency vulnerabilities** — outdated packages with known CVEs, unused dependencies that increase attack surface, and missing lockfile integrity checks.
-- **Insecure configurations** — overly permissive CORS policies, missing security headers, debug mode enabled, verbose error messages exposing internals, and misconfigured cloud resources.
-- **Logging & audit gaps** — sensitive data in log output (PII, tokens, passwords), missing audit trails for security-critical operations, and insufficient monitoring of auth events.
+- **Command & script injection** — user-controlled input flowing into shell commands, `eval`, template engines, or string interpolation without sanitization. In GitHub Actions workflows, look for `${{ }}` expressions used directly in `run:` blocks where issue titles, branch names, or PR bodies could inject arbitrary commands.
+- **Secrets & credential exposure** — hardcoded API keys, tokens, passwords, or connection strings in source code or CI configs. Secrets logged in workflow output, printed in error messages, or accessible to pull requests from forks. Environment variables containing secrets used without masking.
+- **Unsafe shell patterns** — unquoted variable expansion, missing `set -euo pipefail`, unsafe use of `eval` or backticks, word splitting on user input, and TOCTOU races in file operations.
+- **Dependency & supply chain risks** — actions or packages referenced by mutable tag instead of commit SHA, outdated dependencies with known CVEs, unused dependencies that increase attack surface, and missing lockfile integrity.
+- **Permissions over-scoping** — workflow permissions broader than needed, overly permissive IAM or RBAC policies, tokens with write access when read-only suffices, and missing principle-of-least-privilege enforcement.
+- **Input validation gaps** — missing or insufficient validation on API inputs, webhook payloads, file paths, and configuration values. Look for path traversal, unsafe deserialization, and places where external input is trusted without verification.
+- **Sensitive data in logs** — PII, tokens, passwords, or internal details written to log output, error responses, or tracking comments. Missing audit trails for security-critical operations.
 
 ## Scanning Strategy
 
-1. **Check recent changes first.** Run `git log --since="48 hours ago" --name-only --pretty=format:""` to find recently modified files. Security review changes to auth flows, API handlers, data access layers, and infrastructure configs.
-2. **Trace data flows.** For API endpoints and Lambda handlers, trace user input from entry point through processing to storage/output. Look for missing validation or sanitization at each step.
-3. **Audit auth boundaries.** Check that authorization is enforced consistently — look for handlers missing auth middleware, resolvers without permission checks, and direct database access bypassing access control.
-4. **Review secrets hygiene.** Search for patterns like hardcoded strings resembling keys/tokens, environment variables used without validation, and secrets not managed through proper secret stores.
-5. **Check dependency health.** Review `package.json` and lockfiles for known vulnerable versions. Flag dependencies that haven't been updated in a long time.
-6. **Don't re-scan everything.** Check your dashboard for areas already reviewed. Focus on new or changed areas.
-7. **Prioritize by severity.** Remote code execution > auth bypass > data exposure > information disclosure > hardening improvements. Focus on issues an attacker could realistically exploit.
-8. **Be precise.** Include specific file paths, line numbers, and concrete exploit scenarios. Vague "this could be insecure" findings are not actionable.
+1. **Check recent changes first.** Run `git log --since="48 hours ago" --name-only --pretty=format:""` to find recently modified files. Focus security review on shell scripts, workflow files, configuration, and code handling credentials or user input.
+2. **Trace untrusted input.** For each changed file, identify where external input enters (GitHub event context, user input, environment variables, file contents) and trace it through to where it's used. Flag any path where input reaches a sensitive operation without validation or escaping.
+3. **Review secrets hygiene.** Search for patterns resembling hardcoded keys/tokens, environment variables used without validation, and secrets not managed through proper secret stores or GitHub Actions secrets.
+4. **Check dependency pinning.** Verify that GitHub Actions use commit SHA pinning (not `@v1` or `@main`), and that package dependencies are up to date. Flag dependencies not updated in a long time.
+5. **Don't re-scan everything.** Check your dashboard for areas already reviewed. Focus on new or changed areas.
+6. **Prioritize by severity.** Remote code execution > injection > credential exposure > information disclosure > hardening. Focus on issues an attacker could realistically exploit.
+7. **Be precise.** Include specific file paths, line numbers, and concrete exploit scenarios. Vague "this could be insecure" findings are not actionable.


### PR DESCRIPTION
## Summary

- Add `security-engineer` persistent engineer agent profile with focus areas tailored to real-world risks: command/script injection (including GitHub Actions expression injection), secrets exposure, unsafe shell patterns, supply chain risks (action SHA pinning), permissions over-scoping, input validation gaps, and sensitive data in logs
- Add `security-engineer` manager job to `repo-engineer-managers.yml` to run daily alongside docs-engineer and code-janitor
- Rewrite focus areas and scanning strategy from original generic web-app checklist to be practical and technology-appropriate for repos using GitHub Actions and shell scripts

## Test plan

- [ ] Verify `repo-engineer-managers.yml` is valid YAML and the new job follows the same pattern as existing jobs
- [ ] Verify `security-engineer.md` follows the same structure as `docs-engineer.md` and `code-janitor.md`
- [ ] Manually trigger workflow dispatch to confirm the security engineer job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)