### PR TITLE
fix(workflows): add contents:read permission for ci-retry commit counting

### DIFF
--- a/.github/workflows/shared-claude-engineers.yml
+++ b/.github/workflows/shared-claude-engineers.yml
@@ -407,6 +407,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: read
+      contents: read
     steps:
       - name: Check Claude PR and retry
         env:


### PR DESCRIPTION
## Summary

Fixes the \`ci-retry\` job in the shared Claude engineers workflow by adding the missing \`contents: read\` permission. This resolves GraphQL permission errors when querying PR commit data for retry logic.

## Problem

The \`ci-retry\` job fails with this error:
\`\`\`
GraphQL: Resource not accessible by integration (repository.pullRequest.commits.nodes.0)
\`\`\`

**Root cause:** Line 443 calls \`gh pr view "$PR_NUMBER" --json commits\` to count commits for retry logic, but the GraphQL query requires \`contents: read\` permission to access commit data through PR objects.

## Solution

Add \`contents: read\` to the \`ci-retry\` job permissions block:

\`\`\`yaml
ci-retry:
  permissions:
    issues: write
    pull-requests: read
    contents: read  # needed for gh pr view --json commits
\`\`\`

## Impact

- ✅ Fixes permission error blocking CI retry functionality
- ✅ Minimal change following principle of least privilege
- ✅ No functional changes to retry logic
- ✅ Read-only permission, no security risks

## Testing

After this fix, the \`ci-retry\` job will successfully count PR commits without permission errors.

**Run:** [View workflow run](https://github.com/diranged/claude-code-agentic-workflows/actions/runs/22834714645)

Closes #113