### PR TITLE
feat(workflows): add dequeue mechanism for queued implementations

### DIFF
--- a/.github/workflows/repo-claude-engineers.yml
+++ b/.github/workflows/repo-claude-engineers.yml
@@ -3,6 +3,8 @@ name: "Claude Engineers"
 on:
   issues:
     types: [labeled]
+  pull_request:
+    types: [closed]
   workflow_run:
     workflows: ["Tests", "Conventional Commit Check"]
     types: [completed]
@@ -23,6 +25,83 @@ jobs:
       allowed_tools: "Bash(*),Read,Glob,Grep,Edit,Write,WebFetch,WebSearch"
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+
+  # Dequeue: when a PR is closed/merged, promote queued issues if slots are available
+  dequeue:
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Promote queued issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAX_IMPL: "2"
+          LABEL_PREFIX: "claude"
+        run: |
+          set -euo pipefail
+
+          # Count current implementations
+          IMPL_ISSUES=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "${LABEL_PREFIX}:implement" \
+            --state open \
+            --json number \
+            --jq 'length')
+
+          CLAUDE_PRS=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --json number,author \
+            --jq '[.[] | select(.author.login | test("claude|\\[bot\\]"))] | length')
+
+          TOTAL=$((IMPL_ISSUES + CLAUDE_PRS))
+          echo "Current slots: ${TOTAL}/${MAX_IMPL}"
+
+          if [ "$TOTAL" -ge "$MAX_IMPL" ]; then
+            echo "No slots available, skipping dequeue"
+            exit 0
+          fi
+
+          SLOTS_AVAILABLE=$((MAX_IMPL - TOTAL))
+
+          # Find oldest queued issues, promote up to available slots
+          QUEUED=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "${LABEL_PREFIX}:queued" \
+            --state open \
+            --json number,createdAt \
+            --jq 'sort_by(.createdAt) | .[].number')
+
+          if [ -z "$QUEUED" ]; then
+            echo "No queued issues to promote"
+            exit 0
+          fi
+
+          PROMOTED=0
+          for ISSUE_NUM in $QUEUED; do
+            if [ "$PROMOTED" -ge "$SLOTS_AVAILABLE" ]; then
+              break
+            fi
+
+            echo "Promoting issue #${ISSUE_NUM} from queue"
+            gh issue edit "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --remove-label "${LABEL_PREFIX}:queued" \
+              --add-label "${LABEL_PREFIX}:implement"
+
+            gh issue comment "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --body "Slot available — promoting from queue to implementation."
+
+            PROMOTED=$((PROMOTED + 1))
+          done
+
+          echo "Promoted ${PROMOTED} issue(s) from queue"
+        shell: bash
 
   # CI retry: re-trigger developer when CI fails on a Claude-authored PR
   ci-retry:

--- a/.github/workflows/shared-claude-engineers.yml
+++ b/.github/workflows/shared-claude-engineers.yml
@@ -3,6 +3,12 @@ name: "Shared: Claude Engineers"
 # Reusable workflow for handling claude:* label triggers on issues.
 # Implements the design -> implement -> CI-retry lifecycle.
 #
+# Concurrency control: When max_implementations > 0, the workflow queues excess
+# implementations with a `claude:queued` label. After each implementation run
+# completes, a dequeue job automatically promotes the oldest queued issue(s).
+# Callers should ALSO add a `pull_request: closed` trigger with their own
+# dequeue job to handle PR merges that free up slots (see example below).
+#
 # Required caller permissions (must be granted by the calling job):
 #   contents: write, issues: write, pull-requests: write, id-token: write
 #
@@ -10,6 +16,8 @@ name: "Shared: Claude Engineers"
 #   on:
 #     issues:
 #       types: [labeled]
+#     pull_request:
+#       types: [closed]
 #     workflow_run:
 #       workflows: ["Tests"]
 #       types: [completed]
@@ -400,7 +408,83 @@ jobs:
             - Max concurrent implementations: ${{ inputs.max_implementations }} (0 = unlimited)
             - Label prefix: ${{ inputs.label_prefix }}
 
-  # Job 5: CI retry — re-trigger developer when CI fails on a Claude-authored PR
+  # Job 5: Dequeue — promote next queued issue(s) when a slot opens
+  dequeue:
+    runs-on: ubuntu-latest
+    needs: [claude-run]
+    if: always() && inputs.ci_retry != 'true' && inputs.max_implementations != '0'
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Promote queued issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAX_IMPL: ${{ inputs.max_implementations }}
+          LABEL_PREFIX: ${{ inputs.label_prefix }}
+        run: |
+          set -euo pipefail
+
+          # Count current implementations
+          IMPL_ISSUES=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "${LABEL_PREFIX}:implement" \
+            --state open \
+            --json number \
+            --jq 'length')
+
+          CLAUDE_PRS=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --json number,author \
+            --jq '[.[] | select(.author.login | test("claude|\\[bot\\]"))] | length')
+
+          TOTAL=$((IMPL_ISSUES + CLAUDE_PRS))
+          echo "Current slots: ${TOTAL}/${MAX_IMPL}"
+
+          if [ "$TOTAL" -ge "$MAX_IMPL" ]; then
+            echo "No slots available, skipping dequeue"
+            exit 0
+          fi
+
+          SLOTS_AVAILABLE=$((MAX_IMPL - TOTAL))
+
+          # Find oldest queued issues, promote up to available slots
+          QUEUED=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "${LABEL_PREFIX}:queued" \
+            --state open \
+            --json number,createdAt \
+            --jq 'sort_by(.createdAt) | .[].number')
+
+          if [ -z "$QUEUED" ]; then
+            echo "No queued issues to promote"
+            exit 0
+          fi
+
+          PROMOTED=0
+          for ISSUE_NUM in $QUEUED; do
+            if [ "$PROMOTED" -ge "$SLOTS_AVAILABLE" ]; then
+              break
+            fi
+
+            echo "Promoting issue #${ISSUE_NUM} from queue"
+            gh issue edit "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --remove-label "${LABEL_PREFIX}:queued" \
+              --add-label "${LABEL_PREFIX}:implement"
+
+            gh issue comment "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --body "Slot available — promoting from queue to implementation."
+
+            PROMOTED=$((PROMOTED + 1))
+          done
+
+          echo "Promoted ${PROMOTED} issue(s) from queue"
+        shell: bash
+
+  # Job 6: CI retry — re-trigger developer when CI fails on a Claude-authored PR
   ci-retry:
     runs-on: ubuntu-latest
     if: inputs.ci_retry == 'true'


### PR DESCRIPTION
## Summary

- Add dequeue job to `shared-claude-engineers.yml` that runs after every `claude-run` completion, promoting the oldest queued issue(s) up to available concurrency slots
- Add dequeue job to `repo-claude-engineers.yml` triggered on `pull_request: closed` events, catching PR merges that free up implementation slots
- Update shared workflow header docs to describe concurrency/dequeue behavior and add `pull_request: closed` to the example caller

Fixes the bug where issues labeled `claude:queued` were never promoted back to `claude:implement` when slots freed up.

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Merge a Claude PR and confirm the dequeue job runs and promotes a queued issue
- [ ] Verify promoted issue triggers the normal `claude:implement` pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)