### PR TITLE
feat(claude-engineer): move concurrency control to engineer capacity management

### DIFF
--- a/.github/workflows/repo-claude-engineers.yml
+++ b/.github/workflows/repo-claude-engineers.yml
@@ -3,8 +3,6 @@ name: "Claude Engineers"
 on:
   issues:
     types: [labeled]
-  pull_request:
-    types: [closed]
   workflow_run:
     workflows: ["Tests", "Conventional Commit Check"]
     types: [completed]
@@ -21,87 +19,9 @@ jobs:
     with:
       runner: diranged-claude-code
       notify_owners: "diranged"
-      max_implementations: "2"
       allowed_tools: "Bash(*),Read,Glob,Grep,Edit,Write,WebFetch,WebSearch"
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
-
-  # Dequeue: when a PR is closed/merged, promote queued issues if slots are available
-  dequeue:
-    if: >-
-      github.event_name == 'pull_request'
-      && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: read
-    steps:
-      - name: Promote queued issues
-        env:
-          GH_TOKEN: ${{ github.token }}
-          MAX_IMPL: "2"
-          LABEL_PREFIX: "claude"
-        run: |
-          set -euo pipefail
-
-          # Count current implementations
-          IMPL_ISSUES=$(gh issue list \
-            --repo "${{ github.repository }}" \
-            --label "${LABEL_PREFIX}:implement" \
-            --state open \
-            --json number \
-            --jq 'length')
-
-          CLAUDE_PRS=$(gh pr list \
-            --repo "${{ github.repository }}" \
-            --state open \
-            --json number,author \
-            --jq '[.[] | select(.author.login | test("claude|\\[bot\\]"))] | length')
-
-          TOTAL=$((IMPL_ISSUES + CLAUDE_PRS))
-          echo "Current slots: ${TOTAL}/${MAX_IMPL}"
-
-          if [ "$TOTAL" -ge "$MAX_IMPL" ]; then
-            echo "No slots available, skipping dequeue"
-            exit 0
-          fi
-
-          SLOTS_AVAILABLE=$((MAX_IMPL - TOTAL))
-
-          # Find oldest queued issues, promote up to available slots
-          QUEUED=$(gh issue list \
-            --repo "${{ github.repository }}" \
-            --label "${LABEL_PREFIX}:queued" \
-            --state open \
-            --json number,createdAt \
-            --jq 'sort_by(.createdAt) | .[].number')
-
-          if [ -z "$QUEUED" ]; then
-            echo "No queued issues to promote"
-            exit 0
-          fi
-
-          PROMOTED=0
-          for ISSUE_NUM in $QUEUED; do
-            if [ "$PROMOTED" -ge "$SLOTS_AVAILABLE" ]; then
-              break
-            fi
-
-            echo "Promoting issue #${ISSUE_NUM} from queue"
-            gh issue edit "$ISSUE_NUM" \
-              --repo "${{ github.repository }}" \
-              --remove-label "${LABEL_PREFIX}:queued" \
-              --add-label "${LABEL_PREFIX}:implement"
-
-            gh issue comment "$ISSUE_NUM" \
-              --repo "${{ github.repository }}" \
-              --body "Slot available — promoting from queue to implementation."
-
-            PROMOTED=$((PROMOTED + 1))
-          done
-
-          echo "Promoted ${PROMOTED} issue(s) from queue"
-        shell: bash
 
   # CI retry: re-trigger developer when CI fails on a Claude-authored PR
   ci-retry:

--- a/.github/workflows/shared-claude-engineers.yml
+++ b/.github/workflows/shared-claude-engineers.yml
@@ -3,12 +3,6 @@ name: "Shared: Claude Engineers"
 # Reusable workflow for handling claude:* label triggers on issues.
 # Implements the design -> implement -> CI-retry lifecycle.
 #
-# Concurrency control: When max_implementations > 0, the workflow queues excess
-# implementations with a `claude:queued` label. After each implementation run
-# completes, a dequeue job automatically promotes the oldest queued issue(s).
-# Callers should ALSO add a `pull_request: closed` trigger with their own
-# dequeue job to handle PR merges that free up slots (see example below).
-#
 # Required caller permissions (must be granted by the calling job):
 #   contents: write, issues: write, pull-requests: write, id-token: write
 #
@@ -16,8 +10,6 @@ name: "Shared: Claude Engineers"
 #   on:
 #     issues:
 #       types: [labeled]
-#     pull_request:
-#       types: [closed]
 #     workflow_run:
 #       workflows: ["Tests"]
 #       types: [completed]
@@ -102,12 +94,6 @@ on:
         description: "Model for unknown labels matching the prefix"
         type: string
         default: "claude-opus-4-20250514"
-
-      # Concurrency control
-      max_implementations:
-        description: "Maximum concurrent implementations (issues with implement label + open Claude PRs). 0 = unlimited."
-        type: string
-        default: "0"
 
       # CI retry configuration
       ci_retry:
@@ -254,90 +240,11 @@ jobs:
           esac
         shell: bash
 
-  # Job 2: Check implementation concurrency before running the developer
-  concurrency-gate:
-    runs-on: ubuntu-latest
-    needs: detect-intent
-    if: inputs.ci_retry != 'true'
-    permissions:
-      issues: write
-      pull-requests: read
-    outputs:
-      allowed: ${{ steps.check.outputs.allowed }}
-    steps:
-      - name: Check implementation concurrency
-        id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-          MAX_IMPL: ${{ inputs.max_implementations }}
-          LABEL_PREFIX: ${{ inputs.label_prefix }}
-          ISSUE_NUMBER: ${{ needs.detect-intent.outputs.issue_number }}
-          DETECTED_AGENT: ${{ needs.detect-intent.outputs.agent }}
-        run: |
-          # Only gate implement agents; design and review always proceed
-          if [ "$DETECTED_AGENT" != "${{ inputs.implement_agent }}" ]; then
-            echo "Not an implementation run — skipping concurrency check"
-            echo "allowed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # 0 means unlimited
-          if [ "$MAX_IMPL" = "0" ]; then
-            echo "No concurrency limit set"
-            echo "allowed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Count issues with the implement label (excluding this one, since the label was just applied)
-          IMPL_ISSUES=$(gh issue list \
-            --repo "${{ github.repository }}" \
-            --label "${LABEL_PREFIX}:implement" \
-            --state open \
-            --json number \
-            --jq "[.[] | select(.number != ${ISSUE_NUMBER})] | length")
-
-          # Count open PRs authored by Claude bots
-          CLAUDE_PRS=$(gh pr list \
-            --repo "${{ github.repository }}" \
-            --state open \
-            --json number,author \
-            --jq '[.[] | select(.author.login | test("claude|\\[bot\\]"))] | length')
-
-          TOTAL=$((IMPL_ISSUES + CLAUDE_PRS))
-          echo "Implementation slots: ${TOTAL}/${MAX_IMPL} in use (${IMPL_ISSUES} implementing + ${CLAUDE_PRS} open PRs)"
-
-          if [ "$TOTAL" -ge "$MAX_IMPL" ]; then
-            echo "Concurrency limit reached — queuing implementation"
-            echo "allowed=false" >> "$GITHUB_OUTPUT"
-
-            # Remove the implement label so it can be re-applied later
-            gh issue edit "$ISSUE_NUMBER" \
-              --repo "${{ github.repository }}" \
-              --remove-label "${LABEL_PREFIX}:implement"
-
-            # Add a queued label
-            gh label create "${LABEL_PREFIX}:queued" \
-              --repo "${{ github.repository }}" \
-              --description "Implementation approved but waiting for a slot" \
-              --color "fbca04" 2>/dev/null || true
-            gh issue edit "$ISSUE_NUMBER" \
-              --repo "${{ github.repository }}" \
-              --add-label "${LABEL_PREFIX}:queued"
-
-            # Post a comment explaining why
-            gh issue comment "$ISSUE_NUMBER" \
-              --repo "${{ github.repository }}" \
-              --body "Implementation queued — ${TOTAL}/${MAX_IMPL} slots in use. Will be picked up when a slot opens."
-          else
-            echo "allowed=true" >> "$GITHUB_OUTPUT"
-          fi
-        shell: bash
-
-  # Job 3: Create a tracking comment
+  # Job 2: Create a tracking comment
   setup:
     runs-on: ubuntu-latest
-    needs: [detect-intent, concurrency-gate]
-    if: inputs.ci_retry != 'true' && needs.concurrency-gate.outputs.allowed == 'true'
+    needs: [detect-intent]
+    if: inputs.ci_retry != 'true'
     permissions:
       issues: write
       pull-requests: write
@@ -364,11 +271,11 @@ jobs:
           echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
         shell: bash
 
-  # Job 4: Run Claude with the routed agent
+  # Job 3: Run Claude with the routed agent
   claude-run:
     runs-on: ${{ inputs.runner }}
-    needs: [detect-intent, concurrency-gate, setup]
-    if: inputs.ci_retry != 'true' && needs.concurrency-gate.outputs.allowed == 'true'
+    needs: [detect-intent, setup]
+    if: inputs.ci_retry != 'true'
     permissions:
       contents: write
       issues: write
@@ -403,88 +310,7 @@ jobs:
           display_report: ${{ inputs.display_report }}
           dry_run: ${{ inputs.dry_run }}
           issue_comment_id: ${{ needs.setup.outputs.comment_id }}
-          prompt: |
-            ## Concurrency Configuration
-            - Max concurrent implementations: ${{ inputs.max_implementations }} (0 = unlimited)
-            - Label prefix: ${{ inputs.label_prefix }}
-
-  # Job 5: Dequeue — promote next queued issue(s) when a slot opens
-  dequeue:
-    runs-on: ubuntu-latest
-    needs: [claude-run]
-    if: always() && inputs.ci_retry != 'true' && inputs.max_implementations != '0'
-    permissions:
-      issues: write
-      pull-requests: read
-    steps:
-      - name: Promote queued issues
-        env:
-          GH_TOKEN: ${{ github.token }}
-          MAX_IMPL: ${{ inputs.max_implementations }}
-          LABEL_PREFIX: ${{ inputs.label_prefix }}
-        run: |
-          set -euo pipefail
-
-          # Count current implementations
-          IMPL_ISSUES=$(gh issue list \
-            --repo "${{ github.repository }}" \
-            --label "${LABEL_PREFIX}:implement" \
-            --state open \
-            --json number \
-            --jq 'length')
-
-          CLAUDE_PRS=$(gh pr list \
-            --repo "${{ github.repository }}" \
-            --state open \
-            --json number,author \
-            --jq '[.[] | select(.author.login | test("claude|\\[bot\\]"))] | length')
-
-          TOTAL=$((IMPL_ISSUES + CLAUDE_PRS))
-          echo "Current slots: ${TOTAL}/${MAX_IMPL}"
-
-          if [ "$TOTAL" -ge "$MAX_IMPL" ]; then
-            echo "No slots available, skipping dequeue"
-            exit 0
-          fi
-
-          SLOTS_AVAILABLE=$((MAX_IMPL - TOTAL))
-
-          # Find oldest queued issues, promote up to available slots
-          QUEUED=$(gh issue list \
-            --repo "${{ github.repository }}" \
-            --label "${LABEL_PREFIX}:queued" \
-            --state open \
-            --json number,createdAt \
-            --jq 'sort_by(.createdAt) | .[].number')
-
-          if [ -z "$QUEUED" ]; then
-            echo "No queued issues to promote"
-            exit 0
-          fi
-
-          PROMOTED=0
-          for ISSUE_NUM in $QUEUED; do
-            if [ "$PROMOTED" -ge "$SLOTS_AVAILABLE" ]; then
-              break
-            fi
-
-            echo "Promoting issue #${ISSUE_NUM} from queue"
-            gh issue edit "$ISSUE_NUM" \
-              --repo "${{ github.repository }}" \
-              --remove-label "${LABEL_PREFIX}:queued" \
-              --add-label "${LABEL_PREFIX}:implement"
-
-            gh issue comment "$ISSUE_NUM" \
-              --repo "${{ github.repository }}" \
-              --body "Slot available — promoting from queue to implementation."
-
-            PROMOTED=$((PROMOTED + 1))
-          done
-
-          echo "Promoted ${PROMOTED} issue(s) from queue"
-        shell: bash
-
-  # Job 6: CI retry — re-trigger developer when CI fails on a Claude-authored PR
+  # Job 4: CI retry — re-trigger developer when CI fails on a Claude-authored PR
   ci-retry:
     runs-on: ubuntu-latest
     if: inputs.ci_retry == 'true'

--- a/claude-engineer/action.yml
+++ b/claude-engineer/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: "Label that starts the design pipeline on delegated issues."
     required: false
     default: "claude:design"
+  max_implementations:
+    description: "Maximum concurrent implementations to allow. Engineer will only promote this many issues to auto_advance at a time. 0 = unlimited."
+    required: false
+    default: "2"
   rotation_days:
     description: "Number of days before rotating the dashboard issue."
     required: false
@@ -95,5 +99,6 @@ runs:
           - Dashboard label: ${{ inputs.dashboard_label }}
           - Task label: ${{ inputs.task_label }}
           - Delegation label: ${{ inputs.delegation_label }}
+          - Max implementations: ${{ inputs.max_implementations }}
           - Rotation days: ${{ inputs.rotation_days }}
           - Force rotation: ${{ inputs.force_rotation }}

--- a/claude-engineer/instructions/00-engineer-base.md
+++ b/claude-engineer/instructions/00-engineer-base.md
@@ -169,11 +169,52 @@ By the time you create an issue, Phase 3 has already confirmed the finding is ne
 
 1. **Create a focused issue** with a clear title and description including file paths and line references where relevant.
 
-2. **Delegate to the design pipeline** by adding the delegation label and the `claude:auto_advance` label:
+2. **Delegate to the design pipeline** by adding the delegation label only:
    ```bash
-   gh issue edit <NUMBER> --repo "$GITHUB_REPOSITORY" --add-label "<delegation_label>" --add-label "claude:auto_advance"
+   gh issue edit <NUMBER> --repo "$GITHUB_REPOSITORY" --add-label "<delegation_label>"
    ```
-   The `claude:auto_advance` label tells the pipeline to proceed through design → review → implement without waiting for human approval at each stage. Issues created by engineer agents are trusted to run autonomously.
+   This triggers the design agent to create an implementation plan. The issue will **not** auto-advance to implementation yet — that happens in Phase 4 based on capacity.
+
+**Do NOT add `claude:auto_advance` when creating issues.** Capacity management (Phase 4) controls when issues are promoted to implementation.
+
+### Phase 4: Capacity Management
+
+After reconciliation and issue creation, decide which designed issues should be promoted to implementation.
+
+1. **Check the `Max implementations` value** from the Task Context. If `0`, skip this phase (unlimited — all issues auto-advance immediately on creation, so add `claude:auto_advance` to new issues in step 2 of Creating Work Items above).
+
+2. **Count in-flight implementations:**
+   ```bash
+   # Issues currently being implemented
+   IMPL_COUNT=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "claude:implement" --state open --json number --jq 'length')
+   # Open PRs from Claude (implementations producing PRs)
+   PR_COUNT=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,author --jq '[.[] | select(.author.login | test("claude|\\[bot\\]"))] | length')
+   TOTAL=$((IMPL_COUNT + PR_COUNT))
+   ```
+
+3. **Find designed issues ready for promotion.** These are issues with your task label that have received a design (look for a tracking comment from the design agent) but do NOT have `claude:auto_advance`:
+   ```bash
+   gh issue list --repo "$GITHUB_REPOSITORY" --label "<task_label>" --state open --json number,title,labels
+   ```
+   Filter to issues that have the delegation label but NOT `claude:auto_advance`.
+
+4. **Promote issues up to available capacity.** For each issue to promote (oldest first), add `claude:auto_advance` and `claude:implement` to trigger implementation:
+   ```bash
+   gh issue edit <NUMBER> --repo "$GITHUB_REPOSITORY" --add-label "claude:auto_advance" --add-label "claude:implement"
+   ```
+
+5. **Log promotions on the dashboard** so you can track what was promoted and when.
+
+### Capacity Management Examples
+
+**Max implementations = 2, currently 1 in flight, 3 designed issues waiting:**
+> Promote 1 issue (the oldest). After this run, 2 implementations will be in flight (at the limit). The other 2 designed issues wait for the next run.
+
+**Max implementations = 2, currently 0 in flight, 3 designed issues waiting:**
+> Promote 2 issues. The third waits for the next run.
+
+**Max implementations = 0 (unlimited):**
+> Skip capacity management entirely. Add `claude:auto_advance` to issues at creation time.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

Replace the broken workflow-level concurrency gate + dequeue mechanism with engineer-controlled capacity management.

**Problem:** The concurrency gate (PR #98) queued implementations with `claude:queued` labels, but the dequeue (PR #115) couldn't promote them because `GITHUB_TOKEN` label changes don't trigger workflow runs. `repository_dispatch` was the workaround but added significant complexity.

**Solution:** Move concurrency control to the engineer agents themselves. Engineers run inside Claude Code which uses OAuth tokens for `gh` CLI — their label changes **do** trigger workflows. This eliminates the need for dequeue entirely.

### How it works now

1. Engineer creates issues with `claude:design` only (no `claude:auto_advance`)
2. Design agent runs automatically, produces a plan, stops
3. On next engineer run, Phase 4 (Capacity Management) checks in-flight implementations
4. Promotes designed issues by adding `claude:auto_advance` + `claude:implement` (up to `max_implementations` limit)
5. Label changes from Claude Code trigger the implementation pipeline naturally

### Changes

- **shared-claude-engineers.yml**: Remove concurrency gate job, dequeue job, and `max_implementations` input (-100 lines)
- **repo-claude-engineers.yml**: Remove `pull_request: closed` trigger, dequeue job, and `max_implementations` reference
- **claude-engineer/action.yml**: Add `max_implementations` input (default: 2), pass to prompt context
- **claude-engineer/instructions/00-engineer-base.md**: Add Phase 4 (Capacity Management), update Work Delegation to not add `auto_advance` at creation time

Net: -208 lines of workflow infrastructure replaced by ~45 lines of prompt instructions.

## Test plan

- [ ] Verify shared workflow YAML is valid (no dangling job references)
- [ ] Run an engineer manually — confirm it creates issues without `auto_advance`
- [ ] On second run, confirm engineer checks capacity and promotes designed issues
- [ ] Verify promoted issues trigger the implementation pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)