### PR TITLE
fix(workflows): skip early when assignee doesn't match assignee_trigger

### DIFF
--- a/.github/workflows/repo-claude-responder.yml
+++ b/.github/workflows/repo-claude-responder.yml
@@ -18,7 +18,8 @@ jobs:
         && github.event.sender.type != 'Bot'
         && contains(github.event.comment.body, '@claude'))
       || (github.event_name == 'issues' && github.event.action == 'assigned'
-        && !github.event.issue.pull_request)
+        && !github.event.issue.pull_request
+        && github.event.assignee.login == 'claude')
     uses: ./.github/workflows/shared-claude-responder.yml
     with:
       runner: diranged-claude-code

--- a/.github/workflows/shared-claude-responder.yml
+++ b/.github/workflows/shared-claude-responder.yml
@@ -23,7 +23,8 @@ name: "Shared: Claude Responder"
 #         || (github.event_name == 'pull_request_review_comment'
 #           && github.event.sender.type != 'Bot'
 #           && contains(github.event.comment.body, '@claude'))
-#         || (github.event_name == 'issues' && github.event.action == 'assigned')
+#         || (github.event_name == 'issues' && github.event.action == 'assigned'
+#           && github.event.assignee.login == 'claude')
 #       permissions:
 #         contents: write
 #         issues: write
@@ -157,9 +158,42 @@ on:
         required: false
 
 jobs:
+  # Job 0: Check if this event should be handled
+  should-run:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.check.outputs.result }}
+    steps:
+      - name: Check trigger relevance
+        id: check
+        run: |
+          EVENT="${{ github.event_name }}"
+          ACTION="${{ github.event.action }}"
+          ASSIGNEE_TRIGGER="${{ inputs.assignee_trigger }}"
+
+          # For assignment events, skip if assignee doesn't match
+          if [ "$EVENT" = "issues" ] && [ "$ACTION" = "assigned" ]; then
+            ASSIGNEE="${{ github.event.assignee.login }}"
+            if [ -z "$ASSIGNEE_TRIGGER" ]; then
+              echo "::notice::Skipping: issues/assigned event but no assignee_trigger configured"
+              echo "result=skip" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$ASSIGNEE" != "$ASSIGNEE_TRIGGER" ]; then
+              echo "::notice::Skipping: assigned to '$ASSIGNEE' but assignee_trigger is '$ASSIGNEE_TRIGGER'"
+              echo "result=skip" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          echo "result=run" >> "$GITHUB_OUTPUT"
+        shell: bash
+
   # Job 1: React and create a tracking comment
   setup:
     runs-on: ubuntu-latest
+    needs: should-run
+    if: needs.should-run.outputs.result == 'run'
     permissions:
       issues: write
       pull-requests: write
@@ -210,7 +244,8 @@ jobs:
   # Job 2: Run Claude
   claude-run:
     runs-on: ${{ inputs.runner }}
-    needs: setup
+    needs: [should-run, setup]
+    if: needs.should-run.outputs.result == 'run'
     permissions:
       contents: write
       issues: write

--- a/examples/claude.yml
+++ b/examples/claude.yml
@@ -28,7 +28,8 @@ jobs:
         (github.event_name == 'issue_comment'
           && github.event.sender.type != 'Bot'
           && contains(github.event.comment.body, '@claude'))
-        || (github.event_name == 'issues' && github.event.action == 'assigned')
+        || (github.event_name == 'issues' && github.event.action == 'assigned'
+          && github.event.assignee.login == 'claude')
         || (github.event_name == 'issues' && github.event.action == 'labeled'
           && startsWith(github.event.label.name, 'claude:'))
       )


### PR DESCRIPTION
## Summary
- Adds a `should-run` gate job to `shared-claude-responder.yml` that checks if an `issues/assigned` event matches the configured `assignee_trigger` before proceeding
- Prevents wasting runner slots and creating orphaned tracking comments when a non-Claude user is assigned to an issue
- Updates caller workflow examples (`repo-claude-responder.yml`, `examples/claude.yml`) to also filter by assignee login in the `if` condition for defense in depth

## Context
Discovered via [Sproutbook run 22931076392](https://github.com/Sproutbook/sproutbook-backend-amplify/actions/runs/22931076392) — assigning `diranged` to issue #551 triggered the Claude Responder workflow even though `assignee_trigger` was set to `claude`.

## Test plan
- [ ] Verify CI passes (workflow validation, unit tests)
- [ ] Assign a non-Claude user to an issue — workflow should skip with a notice
- [ ] Assign `claude` to an issue — workflow should run normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)