### PR TITLE
fix(agents): add project setup and CI check steps to developer workflow

### DIFF
--- a/claude-core/agents/agentic-developer.md
+++ b/claude-core/agents/agentic-developer.md
@@ -6,15 +6,16 @@ You are operating as an **implementation agent**. Your job is to read an approve
 
 1. **Read the issue and design** — use `gh issue view $ISSUE_NUMBER --comments` (or curl fallback per the GitHub instructions) to get the issue body and all comments. Find the most recent design document (look for the `data-claude-tracking-comment` marker). Understand the full scope.
 2. **Create a feature branch** — use the naming convention `claude/{issue_number}-{short-description}` (e.g., `claude/42-add-auth-middleware`).
-3. **Implement the changes** — follow the design document. Write clean, well-structured code that matches existing patterns.
-4. **Write tests** — add tests as specified in the design's test plan. Ensure adequate coverage.
-5. **Run tests** — execute the project's test suite (`make test`). Fix any failures before proceeding.
-6. **Create a pull request** — use `gh pr create` to open a PR with:
+3. **Set up the project environment** — read the CI workflow (`.github/workflows/test.yml` or similar) to discover what checks CI runs (formatting, linting, type checking, tests). Install project dependencies (including dev dependencies) so that formatters, linters, and git hooks are available.
+4. **Implement the changes** — follow the design document. Write clean, well-structured code that matches existing patterns.
+5. **Write tests** — add tests as specified in the design's test plan. Ensure adequate coverage.
+6. **Run ALL CI checks locally before committing** — run the same checks CI runs: formatting (`prettier --write`, `black`, etc.), linting, type checking, and tests. Fix any issues. Do NOT commit code that hasn't passed formatting and linting.
+7. **Create a pull request** — use `gh pr create` to open a PR with:
    - A clear title summarizing the change.
    - `Closes #ISSUE_NUMBER` in the PR body to auto-close the issue on merge.
    - A summary of what was implemented and any deviations from the design.
    - A link to the workflow run: `**Run:** [View workflow run](<RUN_URL>)`
-7. **Update tracking comment** — set status to "Completed" with a link to the PR and the workflow run.
+8. **Update tracking comment** — set status to "Completed" with a link to the PR and the workflow run.
 
 ## Linking to the Workflow Run
 

--- a/claude-core/tests/test_compose_prompt.py
+++ b/claude-core/tests/test_compose_prompt.py
@@ -567,6 +567,19 @@ class TestComposePrompt(unittest.TestCase):
         self.assertNotIn("Use `make test` which manages its own virtualenvs", prompt)
         self.assertNotIn("python3 -m venv .venv && .venv/bin/pip install -r ../requirements-test.txt", prompt)
 
+    def test_agentic_developer_workflow_includes_setup_and_ci_checks(self):
+        """agentic-developer workflow should include project setup and CI check steps."""
+        rc, _, _, outputs = self._run({"AGENT_NAME": "agentic-developer"})
+        self.assertEqual(rc, 0)
+        prompt = outputs.get("prompt", "")
+        # Workflow should include project environment setup step
+        self.assertIn("Set up the project environment", prompt)
+        self.assertIn("read the CI workflow", prompt)
+        # Workflow should include running ALL CI checks before committing
+        self.assertIn("Run ALL CI checks locally before committing", prompt)
+        # Old prescriptive make test step should be gone
+        self.assertNotIn("execute the project's test suite (`make test`)", prompt)
+
     def test_base_instructions_defer_to_project_setup(self):
         """Base instructions should instruct to follow project setup instructions."""
         rc, _, _, outputs = self._run()


### PR DESCRIPTION
## Summary

Follow-up to #148. The previous fix updated the Environment Awareness section to use deferential language, but the **Workflow** numbered steps still contained `make test` in step 5 — which the agent follows literally as its execution plan.

This was validated against `Sproutbook/sproutbook-backend-amplify#610` where the agent created PR #616 that failed CI on `prettier` formatting — same failure as before the fix.

## Changes

- **Step 3 (new):** "Set up the project environment" — read CI workflow, install deps
- **Step 5→6:** Replaced `make test` with "Run ALL CI checks locally before committing" — formatting, linting, type checking, tests
- Renumbered steps 6→7, 7→8
- Added test `test_agentic_developer_workflow_includes_setup_and_ci_checks`

## Test Plan

- [x] 160 unit tests pass locally
- [ ] CI passes
- [ ] Re-test against sproutbook-backend-amplify#610 after merge

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>