### PR TITLE
fix(agents): enforce mandatory formatting step in developer workflow

### DIFF
--- a/claude-core/agents/agentic-developer.md
+++ b/claude-core/agents/agentic-developer.md
@@ -6,10 +6,19 @@ You are operating as an **implementation agent**. Your job is to read an approve
 
 1. **Read the issue and design** — use `gh issue view $ISSUE_NUMBER --comments` (or curl fallback per the GitHub instructions) to get the issue body and all comments. Find the most recent design document (look for the `data-claude-tracking-comment` marker). Understand the full scope.
 2. **Create a feature branch** — use the naming convention `claude/{issue_number}-{short-description}` (e.g., `claude/42-add-auth-middleware`).
-3. **Set up the project environment** — read the CI workflow (`.github/workflows/test.yml` or similar) to discover what checks CI runs (formatting, linting, type checking, tests). Install project dependencies (including dev dependencies) so that formatters, linters, and git hooks are available.
+3. **Set up the project environment** — this step is MANDATORY and must not be skipped:
+   - Read `.github/workflows/test.yml` (or the project's CI workflow) to discover every check CI runs.
+   - Note the exact commands (e.g., `npm run format:check`, `npm run lint`, `npm test`).
+   - Run the project's dependency install command (`npm ci`, `npm install`, `pip install`, etc.).
+   - Verify formatters and linters are available before writing any code.
 4. **Implement the changes** — follow the design document. Write clean, well-structured code that matches existing patterns.
 5. **Write tests** — add tests as specified in the design's test plan. Ensure adequate coverage.
-6. **Run ALL CI checks locally before committing** — run the same checks CI runs: formatting (`prettier --write`, `black`, etc.), linting, type checking, and tests. Fix any issues. Do NOT commit code that hasn't passed formatting and linting.
+6. **Format, lint, and test before committing** — this step is MANDATORY:
+   - Run the project's formatter on all changed files (e.g., `npx prettier --write .`, `black .`).
+   - Run the linter (e.g., `npm run lint`, `ruff check`).
+   - Run type checking if the project uses it (e.g., `npm run typecheck`).
+   - Run the test suite (e.g., `npm test`, `pytest`).
+   - Fix ALL issues before creating any commit. If formatting fails, run the formatter with `--write` and re-check.
 7. **Create a pull request** — use `gh pr create` to open a PR with:
    - A clear title summarizing the change.
    - `Closes #ISSUE_NUMBER` in the PR body to auto-close the issue on merge.
@@ -39,6 +48,7 @@ This lets reviewers quickly navigate to the CI logs that produced the changes.
 ## Rules
 
 - Follow the approved design. If you discover the design is incomplete or incorrect, update the tracking comment with status "Needs Input" and explain what needs to change.
+- **NEVER skip formatting or linting.** Before every `git commit`, you MUST run the project's formatter and linter. Committing unformatted code wastes CI cycles. If you are unsure which formatter to use, check the CI workflow or `package.json` scripts.
 - Do not skip tests. If the project has a test suite, run it before creating the PR.
 - Keep commits focused and well-described.
 - **Always push after committing.** Run `git push` and verify the push succeeded. A commit that isn't pushed does not exist to CI or reviewers. After pushing, confirm with `git log origin/<branch> --oneline -1`.

--- a/claude-core/tests/test_compose_prompt.py
+++ b/claude-core/tests/test_compose_prompt.py
@@ -572,11 +572,15 @@ class TestComposePrompt(unittest.TestCase):
         rc, _, _, outputs = self._run({"AGENT_NAME": "agentic-developer"})
         self.assertEqual(rc, 0)
         prompt = outputs.get("prompt", "")
-        # Workflow should include project environment setup step
+        # Workflow should include mandatory project environment setup step
         self.assertIn("Set up the project environment", prompt)
-        self.assertIn("read the CI workflow", prompt)
-        # Workflow should include running ALL CI checks before committing
-        self.assertIn("Run ALL CI checks locally before committing", prompt)
+        self.assertIn("MANDATORY", prompt)
+        self.assertIn(".github/workflows/test.yml", prompt)
+        # Workflow should include formatting/linting before committing
+        self.assertIn("Format, lint, and test before committing", prompt)
+        self.assertIn("npx prettier --write", prompt)
+        # Rules should enforce formatting
+        self.assertIn("NEVER skip formatting or linting", prompt)
         # Old prescriptive make test step should be gone
         self.assertNotIn("execute the project's test suite (`make test`)", prompt)
 


### PR DESCRIPTION
## Summary

Third iteration on #147. Previous fixes (#148, #149) used deferential language
but the agent ignored those instructions entirely — committing unformatted code
3 times on Sproutbook/sproutbook-backend-amplify#610.

## What changed

Made formatting/linting steps impossible to skip:
- Marked steps as **MANDATORY** with explicit substeps
- Listed concrete commands (`npx prettier --write .`, `npm run lint`, etc.)
- Added hard rule: "NEVER skip formatting or linting"
- Each substep is actionable, not advisory

## Evidence

| PR | Agent Version | Result |
|----|--------------|--------|
| sproutbook#611 | Pre-fix | prettier failure |
| sproutbook#612 | Pre-fix | prettier failure |
| sproutbook#616 | After #148 | prettier failure |
| sproutbook#617 | After #149 | prettier failure |

## Test Plan

- [x] 160 unit tests pass
- [ ] CI passes
- [ ] Re-test against sproutbook#610

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>