### PR TITLE
fix(agents): enforce formatter execution before git commit

### DIFF
--- a/claude-core/agents/agentic-developer.md
+++ b/claude-core/agents/agentic-developer.md
@@ -6,19 +6,10 @@ You are operating as an **implementation agent**. Your job is to read an approve
 
 1. **Read the issue and design** — use `gh issue view $ISSUE_NUMBER --comments` (or curl fallback per the GitHub instructions) to get the issue body and all comments. Find the most recent design document (look for the `data-claude-tracking-comment` marker). Understand the full scope.
 2. **Create a feature branch** — use the naming convention `claude/{issue_number}-{short-description}` (e.g., `claude/42-add-auth-middleware`).
-3. **Set up the project environment** — this step is MANDATORY and must not be skipped:
-   - Read `.github/workflows/test.yml` (or the project's CI workflow) to discover every check CI runs.
-   - Note the exact commands (e.g., `npm run format:check`, `npm run lint`, `npm test`).
-   - Run the project's dependency install command (`npm ci`, `npm install`, `pip install`, etc.).
-   - Verify formatters and linters are available before writing any code.
+3. **Set up the project environment** — read the CI workflow (`.github/workflows/ci.yml`, `test.yml`, or similar) and note every quality check it runs. Then install all dependencies (`npm ci`, `pip install -r requirements.txt`, etc.) so formatters, linters, and test tools are available.
 4. **Implement the changes** — follow the design document. Write clean, well-structured code that matches existing patterns.
 5. **Write tests** — add tests as specified in the design's test plan. Ensure adequate coverage.
-6. **Format, lint, and test before committing** — this step is MANDATORY:
-   - Run the project's formatter on all changed files (e.g., `npx prettier --write .`, `black .`).
-   - Run the linter (e.g., `npm run lint`, `ruff check`).
-   - Run type checking if the project uses it (e.g., `npm run typecheck`).
-   - Run the test suite (e.g., `npm test`, `pytest`).
-   - Fix ALL issues before creating any commit. If formatting fails, run the formatter with `--write` and re-check.
+6. **Run quality checks, then commit** — follow the Safe Commit Workflow skill exactly. The sequence is: format → lint → test → stage → commit. You must run the project's formatter (e.g., `npx prettier --write .`) and verify it passes BEFORE running `git add` or `git commit`. Do NOT proceed to `git add` until the formatter and linter have run successfully.
 7. **Create a pull request** — use `gh pr create` to open a PR with:
    - A clear title summarizing the change.
    - `Closes #ISSUE_NUMBER` in the PR body to auto-close the issue on merge.
@@ -48,7 +39,7 @@ This lets reviewers quickly navigate to the CI logs that produced the changes.
 ## Rules
 
 - Follow the approved design. If you discover the design is incomplete or incorrect, update the tracking comment with status "Needs Input" and explain what needs to change.
-- **NEVER skip formatting or linting.** Before every `git commit`, you MUST run the project's formatter and linter. Committing unformatted code wastes CI cycles. If you are unsure which formatter to use, check the CI workflow or `package.json` scripts.
+- **NEVER run `git commit` without first running the formatter and linter.** The correct order is always: format → lint → test → `git add` → `git commit`. If you are about to run `git add` and have not yet run the formatter, STOP and run it first. Check the CI workflow or `package.json` scripts to find the formatter command.
 - Do not skip tests. If the project has a test suite, run it before creating the PR.
 - Keep commits focused and well-described.
 - **Always push after committing.** Run `git push` and verify the push succeeded. A commit that isn't pushed does not exist to CI or reviewers. After pushing, confirm with `git log origin/<branch> --oneline -1`.

--- a/claude-core/instructions/00-base.md
+++ b/claude-core/instructions/00-base.md
@@ -8,6 +8,7 @@ You are Claude, an AI assistant helping with software engineering tasks in a Git
 - Be concise and focused — only make changes that are directly requested or clearly necessary.
 - Follow existing code patterns, naming conventions, and project structure.
 - Write tests for new functionality. Run existing tests before opening a PR to avoid regressions.
+- **Before every `git commit`:** run the project's formatter and linter first. The sequence is always: format → lint → test → `git add` → `git commit`. Never commit unformatted code.
 - Do not add unnecessary dependencies, comments, or abstractions.
 - When modifying existing files, preserve the surrounding style (indentation, formatting, idioms).
 

--- a/claude-core/skills/safe-commit.md
+++ b/claude-core/skills/safe-commit.md
@@ -1,0 +1,68 @@
+# Skill: Safe Commit Workflow
+
+## How to Commit Code
+
+**You MUST follow this exact sequence every time you commit code.** Never run `git commit` without completing the pre-commit checks first.
+
+### Step 1: Discover project quality checks
+
+Before your first commit, read the project's CI workflow to learn what checks run:
+
+```bash
+cat .github/workflows/ci.yml    # or test.yml, check.yml, etc.
+cat package.json                 # look for "scripts" section
+```
+
+Note every command CI runs (formatters, linters, type checkers, tests).
+
+### Step 2: Install dependencies
+
+```bash
+npm ci          # Node.js projects
+pip install -r requirements.txt  # Python projects
+```
+
+### Step 3: Write your code changes
+
+Implement the required changes.
+
+### Step 4: Run ALL quality checks BEFORE staging
+
+This is the critical step that must not be skipped. Run every check that CI runs:
+
+```bash
+# Example for a Node.js project with prettier:
+npx prettier --write .        # Auto-fix formatting
+npm run lint -- --fix         # Auto-fix lint issues (if applicable)
+npm run typecheck             # Type checking (if applicable)
+npm test                      # Run tests
+
+# Example for a Python project:
+black .                       # Auto-fix formatting
+ruff check --fix .            # Auto-fix lint issues
+pytest                        # Run tests
+```
+
+**If any check fails, fix the issue and re-run ALL checks.**
+
+### Step 5: Stage and commit
+
+Only after ALL quality checks pass:
+
+```bash
+git add <files>
+git commit -m "your message"
+```
+
+### Step 6: Push and verify
+
+```bash
+git push -u origin <branch>
+git log origin/<branch> --oneline -1   # Verify push succeeded
+```
+
+## Critical Rule
+
+**The sequence is: code → format → lint → test → stage → commit → push.**
+
+Never reorder these steps. Never skip the format/lint/test steps. If you find yourself about to run `git commit` and you have not yet run the formatter, STOP and run it first.

--- a/claude-core/tests/test_compose_prompt.py
+++ b/claude-core/tests/test_compose_prompt.py
@@ -572,15 +572,16 @@ class TestComposePrompt(unittest.TestCase):
         rc, _, _, outputs = self._run({"AGENT_NAME": "agentic-developer"})
         self.assertEqual(rc, 0)
         prompt = outputs.get("prompt", "")
-        # Workflow should include mandatory project environment setup step
+        # Workflow should include project environment setup step
         self.assertIn("Set up the project environment", prompt)
-        self.assertIn("MANDATORY", prompt)
-        self.assertIn(".github/workflows/test.yml", prompt)
-        # Workflow should include formatting/linting before committing
-        self.assertIn("Format, lint, and test before committing", prompt)
+        # Workflow step 6 should reference Safe Commit Workflow and enforce ordering
+        self.assertIn("Safe Commit Workflow", prompt)
+        self.assertIn("format", prompt)
         self.assertIn("npx prettier --write", prompt)
-        # Rules should enforce formatting
-        self.assertIn("NEVER skip formatting or linting", prompt)
+        # Rules should enforce formatting before git commit
+        self.assertIn("NEVER run `git commit` without first running the formatter", prompt)
+        # Safe Commit Workflow skill should be included
+        self.assertIn("code → format → lint → test → stage → commit → push", prompt)
         # Old prescriptive make test step should be gone
         self.assertNotIn("execute the project's test suite (`make test`)", prompt)
 


### PR DESCRIPTION
## Summary
- Adds a new `safe-commit.md` skill that defines the explicit sequence: code → format → lint → test → stage → commit → push
- Restructures the agentic-developer workflow step 6 to reference the Safe Commit Workflow skill
- Adds commit ordering rule to base instructions (applies to ALL agents, not just developer)
- Changes rule language from "NEVER skip formatting" to "NEVER run `git commit` without first running the formatter" — more actionable and specific

## Context
Issue #147: The agentic-developer agent was skipping the formatting step (prettier) before committing, causing CI failures. Analysis of execution artifacts showed the agent going directly from `git add` to `git commit` without running the formatter.

Previous iterations tried:
1. Adding "MANDATORY" language to workflow steps
2. Adding explicit substeps with example commands
3. Adding `.github/claude-instructions/` in consuming repos

This iteration takes a structural approach: a dedicated skill with a concrete checklist, reinforcement at the base instruction level, and language that ties formatting directly to the `git commit` command.

Closes #147

## Test plan
- [x] All 160 unit tests pass
- [ ] Integration test running at diranged/claude-workflows-integration-tests (formatting enforcement test)
- [ ] Verify agent runs prettier before committing in real workflow