### PR TITLE
fix(agents): instruct agent to install missing runtimes before formatting

### DIFF
--- a/claude-core/agents/agentic-developer.md
+++ b/claude-core/agents/agentic-developer.md
@@ -33,6 +33,10 @@ This lets reviewers quickly navigate to the CI logs that produced the changes.
 - **Workflow files cannot be pushed** — the token lacks `workflows` permission. If the design requires `.github/workflows/` changes, exclude them from commits and note what's needed in the tracking comment.
 - **Follow project-specific instructions.** Your system prompt includes project-specific instructions from CLAUDE.md, CONTRIBUTING.md, and other project configuration files. **Always follow those project-specific instructions** for dependency installation, testing, linting, and formatting — they take precedence over any generic defaults.
 - **If no project-specific instructions exist**, detect the project type from config files at the workspace root (package.json, pyproject.toml, go.mod, Cargo.toml, Gemfile, Makefile) and install dependencies (including dev dependencies) before writing code.
+- **Install missing language runtimes.** The runner environment may not have Node.js, Python, or other runtimes pre-installed. If a command like `npm`, `node`, `python3`, or `pip` is not found, install the runtime before proceeding:
+  - **Node.js:** `curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && sudo apt-get install -y nodejs` (or use `nvm`)
+  - **Python:** `sudo apt-get update && sudo apt-get install -y python3 python3-pip`
+  - Do NOT skip dependency installation or quality checks because a runtime is missing. Install it first.
 - **Before committing, run the project's quality checks.** Read the CI workflow (`.github/workflows/test.yml` or similar) to understand what checks CI runs, and run them locally first.
 - **If pre-commit hooks are installed** (husky, pre-commit, etc.), they run automatically on `git commit`. If hooks fail, fix the issues and commit again.
 

--- a/claude-core/skills/safe-commit.md
+++ b/claude-core/skills/safe-commit.md
@@ -15,12 +15,26 @@ cat package.json                 # look for "scripts" section
 
 Note every command CI runs (formatters, linters, type checkers, tests).
 
-### Step 2: Install dependencies
+### Step 2: Install runtime and dependencies
+
+If the required runtime (node, python3, etc.) is not installed, install it first:
+
+```bash
+# If `node` or `npm` is not found:
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && sudo apt-get install -y nodejs
+
+# If `python3` is not found:
+sudo apt-get update && sudo apt-get install -y python3 python3-pip
+```
+
+Then install project dependencies:
 
 ```bash
 npm ci          # Node.js projects
 pip install -r requirements.txt  # Python projects
 ```
+
+**Do NOT skip this step.** If the runtime is missing, install it — do not proceed without it.
 
 ### Step 3: Write your code changes
 


### PR DESCRIPTION
## Summary
Root cause found: the self-hosted runner doesn't have Node.js pre-installed. When the agent runs `npm ci`, it gets `npm: command not found` and then decides to skip all formatting/quality checks.

This PR adds explicit instructions for the agent to install missing runtimes rather than skipping quality checks:
- Updated `agentic-developer.md` with runtime installation guidance
- Updated `safe-commit.md` skill with runtime installation as step 2

## Context
This is a follow-up to #151. The execution artifact from the integration test showed:
```
Result: Exit code 127 — /bin/bash: line 1: npm: command not found
```
After which the agent thought: "It seems Node.js and npm are not available... I can proceed with creating the file first and the CI will handle the formatting checks"

Closes #147

## Test plan
- [x] All 160 unit tests pass
- [ ] Re-run formatting enforcement integration test