### PR TITLE
fix(agents): fail loudly when environment setup fails instead of skipping checks

### DIFF
--- a/claude-core/agents/agentic-developer.md
+++ b/claude-core/agents/agentic-developer.md
@@ -33,17 +33,15 @@ This lets reviewers quickly navigate to the CI logs that produced the changes.
 - **Workflow files cannot be pushed** — the token lacks `workflows` permission. If the design requires `.github/workflows/` changes, exclude them from commits and note what's needed in the tracking comment.
 - **Follow project-specific instructions.** Your system prompt includes project-specific instructions from CLAUDE.md, CONTRIBUTING.md, and other project configuration files. **Always follow those project-specific instructions** for dependency installation, testing, linting, and formatting — they take precedence over any generic defaults.
 - **If no project-specific instructions exist**, detect the project type from config files at the workspace root (package.json, pyproject.toml, go.mod, Cargo.toml, Gemfile, Makefile) and install dependencies (including dev dependencies) before writing code.
-- **Install missing language runtimes.** The runner environment may not have Node.js, Python, or other runtimes pre-installed. If a command like `npm`, `node`, `python3`, or `pip` is not found, install the runtime before proceeding:
-  - **Node.js:** `curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && sudo apt-get install -y nodejs` (or use `nvm`)
-  - **Python:** `sudo apt-get update && sudo apt-get install -y python3 python3-pip`
-  - Do NOT skip dependency installation or quality checks because a runtime is missing. Install it first.
-- **Before committing, run the project's quality checks.** Read the CI workflow (`.github/workflows/test.yml` or similar) to understand what checks CI runs, and run them locally first.
+- **Install missing language runtimes.** The runner environment may not have Node.js, Python, or other runtimes pre-installed. If a command like `npm`, `node`, `python3`, or `pip` is not found, try to install the runtime (see the Safe Commit Workflow skill for installation methods).
+- **If you cannot set up the environment, STOP.** If you cannot install the required runtime or dependencies after multiple attempts, do NOT proceed to write code or commit. Update the tracking comment with status **Failed**, explain what is missing, and run `exit 1`. A failed run with a clear error is far better than a "successful" run that produces unverified, broken code.
+- **Before committing, run the project's quality checks.** Read the CI workflow (`.github/workflows/test.yml` or similar) to understand what checks CI runs, and run them locally first. If you cannot run a quality check, do not commit.
 - **If pre-commit hooks are installed** (husky, pre-commit, etc.), they run automatically on `git commit`. If hooks fail, fix the issues and commit again.
 
 ## Rules
 
 - Follow the approved design. If you discover the design is incomplete or incorrect, update the tracking comment with status "Needs Input" and explain what needs to change.
-- **NEVER run `git commit` without first running the formatter and linter.** The correct order is always: format → lint → test → `git add` → `git commit`. If you are about to run `git add` and have not yet run the formatter, STOP and run it first. Check the CI workflow or `package.json` scripts to find the formatter command.
+- **NEVER run `git commit` without first running the formatter and linter.** The correct order is always: format → lint → test → `git add` → `git commit`. If you are about to run `git add` and have not yet run the formatter, STOP and run it first. If you cannot run the formatter because the environment is broken, do NOT commit — fail with an error instead.
 - Do not skip tests. If the project has a test suite, run it before creating the PR.
 - Keep commits focused and well-described.
 - **Always push after committing.** Run `git push` and verify the push succeeded. A commit that isn't pushed does not exist to CI or reviewers. After pushing, confirm with `git log origin/<branch> --oneline -1`.

--- a/claude-core/instructions/00-base.md
+++ b/claude-core/instructions/00-base.md
@@ -8,7 +8,7 @@ You are Claude, an AI assistant helping with software engineering tasks in a Git
 - Be concise and focused — only make changes that are directly requested or clearly necessary.
 - Follow existing code patterns, naming conventions, and project structure.
 - Write tests for new functionality. Run existing tests before opening a PR to avoid regressions.
-- **Before every `git commit`:** run the project's formatter and linter first. The sequence is always: format → lint → test → `git add` → `git commit`. Never commit unformatted code.
+- **Before every `git commit`:** run the project's formatter and linter first. The sequence is always: format → lint → test → `git add` → `git commit`. Never commit unformatted code. If you cannot run the quality checks because the environment is not set up, do NOT commit — report the failure and exit instead.
 - Do not add unnecessary dependencies, comments, or abstractions.
 - When modifying existing files, preserve the surrounding style (indentation, formatting, idioms).
 

--- a/claude-core/skills/safe-commit.md
+++ b/claude-core/skills/safe-commit.md
@@ -17,14 +17,20 @@ Note every command CI runs (formatters, linters, type checkers, tests).
 
 ### Step 2: Install runtime and dependencies
 
-If the required runtime (node, python3, etc.) is not installed, install it first:
+If the required runtime (node, python3, etc.) is not installed, install it first. Try these approaches in order:
 
 ```bash
-# If `node` or `npm` is not found:
+# If `node` or `npm` is not found, try these in order:
+# 1. Check for node in non-standard paths
+find /usr /home /opt -name "node" -type f 2>/dev/null | head -5
+
+# 2. Install via package manager
 curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && sudo apt-get install -y nodejs
 
-# If `python3` is not found:
-sudo apt-get update && sudo apt-get install -y python3 python3-pip
+# 3. If sudo is unavailable, try nvm
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash
+export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm install 22
 ```
 
 Then install project dependencies:
@@ -34,7 +40,15 @@ npm ci          # Node.js projects
 pip install -r requirements.txt  # Python projects
 ```
 
-**Do NOT skip this step.** If the runtime is missing, install it — do not proceed without it.
+### CRITICAL: Fail if environment setup fails
+
+**If you cannot install the required runtime or dependencies after exhausting all options above, you MUST stop immediately.** Do NOT proceed to write code, do NOT commit, do NOT create a PR.
+
+Instead:
+1. Update the tracking comment with status **Failed** and explain exactly what is missing (e.g., "Node.js is not installed and cannot be installed on this runner").
+2. Exit with an error. Run: `exit 1`
+
+**Never work around a missing environment by skipping quality checks.** Committing code without running the formatter and linter wastes CI cycles and creates broken PRs. It is better to fail loudly than to silently produce unverified code.
 
 ### Step 3: Write your code changes
 
@@ -75,8 +89,8 @@ git push -u origin <branch>
 git log origin/<branch> --oneline -1   # Verify push succeeded
 ```
 
-## Critical Rule
+## Critical Rules
 
-**The sequence is: code → format → lint → test → stage → commit → push.**
+1. **The sequence is: code → format → lint → test → stage → commit → push.** Never reorder these steps. Never skip the format/lint/test steps.
 
-Never reorder these steps. Never skip the format/lint/test steps. If you find yourself about to run `git commit` and you have not yet run the formatter, STOP and run it first.
+2. **If you cannot run the quality checks, do not commit.** A commit without verification is worse than no commit at all. Fail with a clear error message explaining what is missing.


### PR DESCRIPTION
## Summary
When the runner environment is missing required runtimes (Node.js, Python), the agent was silently skipping quality checks, committing unverified code, and reporting "Task Completed Successfully." This produced broken PRs that always fail CI.

Now the agent is instructed to fail fast and fail loudly:
- Stop immediately if environment setup fails after exhausting all installation methods
- Update tracking comment with status **Failed** explaining what's missing
- `exit 1` so the workflow shows red
- Never commit code it cannot verify

## Evidence
Execution artifact from Sproutbook PR #621 showed the agent:
1. Failed to install Node.js (nodesource, nvm, apt all failed on slim runner)
2. Found bun as workaround for prettier only
3. Could not run ESLint
4. Committed and pushed anyway, declaring success
5. CI failed on lint error the agent never checked

## Changes
- `claude-core/skills/safe-commit.md` — added "CRITICAL: Fail if environment setup fails" section
- `claude-core/agents/agentic-developer.md` — added fail-fast rule for missing environments
- `claude-core/instructions/00-base.md` — added "do NOT commit, report failure and exit" to base rules

Closes #147