### PR TITLE
feat(workflows): add github_token secret passthrough to shared workflows

### DIFF
--- a/.github/workflows/shared-claude-engineers.yml
+++ b/.github/workflows/shared-claude-engineers.yml
@@ -30,6 +30,7 @@ name: "Shared: Claude Engineers"
 #         runner: my-self-hosted-runner
 #       secrets:
 #         claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+#         github_token: ${{ secrets.GH_PACKAGES_TOKEN }}  # optional: token for npm/packages auth
 #
 #     ci-retry:
 #       if: >-
@@ -47,6 +48,7 @@ name: "Shared: Claude Engineers"
 #         ci_retry_max: "3"
 #       secrets:
 #         claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+#         github_token: ${{ secrets.GH_PACKAGES_TOKEN }}  # optional: token for npm/packages auth
 
 on:
   workflow_call:
@@ -194,6 +196,9 @@ on:
       anthropic_api_key:
         description: "Anthropic API key (per-token billing)"
         required: false
+      github_token:
+        description: "GitHub token for git/API/npm operations (overrides default GITHUB_TOKEN)"
+        required: false
       app_id:
         description: "GitHub App ID for elevated permissions"
         required: false
@@ -289,6 +294,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          github_token: ${{ secrets.github_token }}
           app_id: ${{ secrets.app_id }}
           app_private_key: ${{ secrets.app_private_key }}
           trigger_phrase: ${{ inputs.trigger_phrase }}

--- a/.github/workflows/shared-claude-responder.yml
+++ b/.github/workflows/shared-claude-responder.yml
@@ -35,6 +35,7 @@ name: "Shared: Claude Responder"
 #         runner: my-self-hosted-runner
 #       secrets:
 #         claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+#         github_token: ${{ secrets.GH_PACKAGES_TOKEN }}  # optional: token for npm/packages auth
 
 on:
   workflow_call:
@@ -150,6 +151,9 @@ on:
       anthropic_api_key:
         description: "Anthropic API key (per-token billing)"
         required: false
+      github_token:
+        description: "GitHub token for git/API/npm operations (overrides default GITHUB_TOKEN)"
+        required: false
       app_id:
         description: "GitHub App ID for elevated permissions"
         required: false
@@ -259,6 +263,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          github_token: ${{ secrets.github_token }}
           app_id: ${{ secrets.app_id }}
           app_private_key: ${{ secrets.app_private_key }}
           trigger_phrase: ${{ inputs.trigger_phrase }}


### PR DESCRIPTION
## Summary

- Adds optional `github_token` secret input to both `shared-claude-engineers.yml` and `shared-claude-responder.yml`
- Forwards the token to the `claude-respond` action's `github_token` input
- When provided, this token becomes `GITHUB_TOKEN` in the agent's environment (set by `claude-code-action`), enabling npm authentication for private GitHub Packages

## Context

Consuming repos like Sproutbook use `.npmrc` with `${GITHUB_TOKEN}` for private `@diranged` scoped packages from GitHub Packages. The default `github.token` doesn't have cross-org packages access, so repos need to pass a dedicated token (e.g., a PAT with `packages:read`).

Without this change, the agent can't run `npm ci` because the token in `GITHUB_TOKEN` doesn't have the right scope for private packages.

## Token Resolution Order

The existing priority chain in `resolve_token.sh` is preserved:
1. App token (from `app_id`/`app_private_key`) — highest priority
2. Explicit `github_token` — **new**: now passable from shared workflows
3. Default `github.token` — fallback

## Test plan

- [x] All existing tests pass (`make test`)
- [ ] Verify on Sproutbook by passing `GH_PACKAGES_TOKEN` as `github_token` and triggering a Claude run

🤖 Generated with [Claude Code](https://claude.com/claude-code)