### PR TITLE
fix(workflows): rename github_token secret to custom_github_token

### DIFF
--- a/.github/workflows/shared-claude-engineers.yml
+++ b/.github/workflows/shared-claude-engineers.yml
@@ -30,7 +30,7 @@ name: "Shared: Claude Engineers"
 #         runner: my-self-hosted-runner
 #       secrets:
 #         claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
-#         github_token: ${{ secrets.GH_PACKAGES_TOKEN }}  # optional: token for npm/packages auth
+#         custom_github_token: ${{ secrets.GH_PACKAGES_TOKEN }}  # optional: token for npm/packages auth
 #
 #     ci-retry:
 #       if: >-
@@ -48,7 +48,7 @@ name: "Shared: Claude Engineers"
 #         ci_retry_max: "3"
 #       secrets:
 #         claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
-#         github_token: ${{ secrets.GH_PACKAGES_TOKEN }}  # optional: token for npm/packages auth
+#         custom_github_token: ${{ secrets.GH_PACKAGES_TOKEN }}  # optional: token for npm/packages auth
 
 on:
   workflow_call:
@@ -196,7 +196,7 @@ on:
       anthropic_api_key:
         description: "Anthropic API key (per-token billing)"
         required: false
-      github_token:
+      custom_github_token:
         description: "GitHub token for git/API/npm operations (overrides default GITHUB_TOKEN)"
         required: false
       app_id:
@@ -294,7 +294,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.custom_github_token }}
           app_id: ${{ secrets.app_id }}
           app_private_key: ${{ secrets.app_private_key }}
           trigger_phrase: ${{ inputs.trigger_phrase }}

--- a/.github/workflows/shared-claude-responder.yml
+++ b/.github/workflows/shared-claude-responder.yml
@@ -35,7 +35,7 @@ name: "Shared: Claude Responder"
 #         runner: my-self-hosted-runner
 #       secrets:
 #         claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
-#         github_token: ${{ secrets.GH_PACKAGES_TOKEN }}  # optional: token for npm/packages auth
+#         custom_github_token: ${{ secrets.GH_PACKAGES_TOKEN }}  # optional: token for npm/packages auth
 
 on:
   workflow_call:
@@ -151,7 +151,7 @@ on:
       anthropic_api_key:
         description: "Anthropic API key (per-token billing)"
         required: false
-      github_token:
+      custom_github_token:
         description: "GitHub token for git/API/npm operations (overrides default GITHUB_TOKEN)"
         required: false
       app_id:
@@ -263,7 +263,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.custom_github_token }}
           app_id: ${{ secrets.app_id }}
           app_private_key: ${{ secrets.app_private_key }}
           trigger_phrase: ${{ inputs.trigger_phrase }}


### PR DESCRIPTION
## Summary

Renames the `github_token` secret to `custom_github_token` in both shared workflows.

## Problem

PR #155 added a `github_token` secret to the shared workflows. When Sproutbook passed a value for this secret, the workflow immediately failed with "workflow file issue" — the workflow couldn't even parse/start.

The name `github_token` likely conflicts with GitHub's built-in `GITHUB_TOKEN` / `github.token` handling in reusable workflows. GitHub may treat it as a reserved name.

## Fix

Rename the secret from `github_token` → `custom_github_token` at the `workflow_call` boundary. The value is still forwarded as `github_token` to the `claude-respond` action input (which doesn't have the same naming restriction since it's a composite action input, not a workflow_call secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)