### PR TITLE
fix(workflows): remove pre_run_secret, let callers inline secrets in pre_run

### DIFF
--- a/.github/workflows/shared-claude-engineers.yml
+++ b/.github/workflows/shared-claude-engineers.yml
@@ -28,10 +28,9 @@ name: "Shared: Claude Engineers"
 #       uses: diranged/claude-code-agentic-workflows/.github/workflows/shared-claude-engineers.yml@v0
 #       with:
 #         runner: my-self-hosted-runner
-#         pre_run: "GITHUB_TOKEN=${PRE_RUN_SECRET} npm ci"  # optional: run before Claude starts
+#         pre_run: "GITHUB_TOKEN=${{ secrets.GH_PACKAGES_TOKEN }} npm ci"  # optional
 #       secrets:
 #         claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
-#         pre_run_secret: ${{ secrets.GH_PACKAGES_TOKEN }}  # optional: exposed as PRE_RUN_SECRET
 #
 #     ci-retry:
 #       if: >-
@@ -208,9 +207,6 @@ on:
       app_private_key:
         description: "GitHub App private key (PEM format)"
         required: false
-      pre_run_secret:
-        description: "Secret value exposed as PRE_RUN_SECRET env var during pre_run commands"
-        required: false
 
 jobs:
   # Job 1: Route label to agent/model and handle CI retry
@@ -298,8 +294,6 @@ jobs:
       - name: Pre-run setup
         if: inputs.pre_run != ''
         run: ${{ inputs.pre_run }}
-        env:
-          PRE_RUN_SECRET: ${{ secrets.pre_run_secret }}
         shell: bash
 
       - name: Run Claude

--- a/.github/workflows/shared-claude-responder.yml
+++ b/.github/workflows/shared-claude-responder.yml
@@ -33,10 +33,9 @@ name: "Shared: Claude Responder"
 #       uses: diranged/claude-code-agentic-workflows/.github/workflows/shared-claude-responder.yml@v0
 #       with:
 #         runner: my-self-hosted-runner
-#         pre_run: "GITHUB_TOKEN=${PRE_RUN_SECRET} npm ci"  # optional: run before Claude starts
+#         pre_run: "GITHUB_TOKEN=${{ secrets.GH_PACKAGES_TOKEN }} npm ci"  # optional
 #       secrets:
 #         claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
-#         pre_run_secret: ${{ secrets.GH_PACKAGES_TOKEN }}  # optional: exposed as PRE_RUN_SECRET
 
 on:
   workflow_call:
@@ -164,9 +163,6 @@ on:
       app_private_key:
         description: "GitHub App private key (PEM format)"
         required: false
-      pre_run_secret:
-        description: "Secret value exposed as PRE_RUN_SECRET env var during pre_run commands"
-        required: false
 
 jobs:
   # Job 0: Check if this event should be handled
@@ -268,8 +264,6 @@ jobs:
       - name: Pre-run setup
         if: inputs.pre_run != ''
         run: ${{ inputs.pre_run }}
-        env:
-          PRE_RUN_SECRET: ${{ secrets.pre_run_secret }}
         shell: bash
 
       - name: Run Claude


### PR DESCRIPTION
## Summary

- Removes `pre_run_secret` secret from both shared workflows
- Callers inline secrets directly in `pre_run`: `pre_run: "GITHUB_TOKEN=${{ secrets.TOKEN }} npm ci"`
- GitHub automatically masks secret values in logs, so no special handling needed

## Example

```yaml
uses: diranged/claude-code-agentic-workflows/.github/workflows/shared-claude-responder.yml@main
with:
  runner: my-runner
  pre_run: "GITHUB_TOKEN=${{ secrets.GH_PACKAGES_TOKEN }} npm ci"
secrets:
  claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)