### PR TITLE
fix(workflows): restore pre_run_secret for reusable workflow compatibility

### DIFF
--- a/.github/workflows/shared-claude-engineers.yml
+++ b/.github/workflows/shared-claude-engineers.yml
@@ -28,9 +28,10 @@ name: "Shared: Claude Engineers"
 #       uses: diranged/claude-code-agentic-workflows/.github/workflows/shared-claude-engineers.yml@v0
 #       with:
 #         runner: my-self-hosted-runner
-#         pre_run: "GITHUB_TOKEN=${{ secrets.GH_PACKAGES_TOKEN }} npm ci"  # optional
+#         pre_run: "GITHUB_TOKEN=${PRE_RUN_SECRET} npm ci"  # optional: run before Claude starts
 #       secrets:
 #         claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+#         pre_run_secret: ${{ secrets.GH_PACKAGES_TOKEN }}  # optional: exposed as PRE_RUN_SECRET
 #
 #     ci-retry:
 #       if: >-
@@ -207,6 +208,9 @@ on:
       app_private_key:
         description: "GitHub App private key (PEM format)"
         required: false
+      pre_run_secret:
+        description: "Secret value exposed as PRE_RUN_SECRET env var during pre_run commands"
+        required: false
 
 jobs:
   # Job 1: Route label to agent/model and handle CI retry
@@ -294,6 +298,8 @@ jobs:
       - name: Pre-run setup
         if: inputs.pre_run != ''
         run: ${{ inputs.pre_run }}
+        env:
+          PRE_RUN_SECRET: ${{ secrets.pre_run_secret }}
         shell: bash
 
       - name: Run Claude

--- a/.github/workflows/shared-claude-responder.yml
+++ b/.github/workflows/shared-claude-responder.yml
@@ -33,9 +33,10 @@ name: "Shared: Claude Responder"
 #       uses: diranged/claude-code-agentic-workflows/.github/workflows/shared-claude-responder.yml@v0
 #       with:
 #         runner: my-self-hosted-runner
-#         pre_run: "GITHUB_TOKEN=${{ secrets.GH_PACKAGES_TOKEN }} npm ci"  # optional
+#         pre_run: "GITHUB_TOKEN=${PRE_RUN_SECRET} npm ci"  # optional: run before Claude starts
 #       secrets:
 #         claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+#         pre_run_secret: ${{ secrets.GH_PACKAGES_TOKEN }}  # optional: exposed as PRE_RUN_SECRET
 
 on:
   workflow_call:
@@ -163,6 +164,9 @@ on:
       app_private_key:
         description: "GitHub App private key (PEM format)"
         required: false
+      pre_run_secret:
+        description: "Secret value exposed as PRE_RUN_SECRET env var during pre_run commands"
+        required: false
 
 jobs:
   # Job 0: Check if this event should be handled
@@ -264,6 +268,8 @@ jobs:
       - name: Pre-run setup
         if: inputs.pre_run != ''
         run: ${{ inputs.pre_run }}
+        env:
+          PRE_RUN_SECRET: ${{ secrets.pre_run_secret }}
         shell: bash
 
       - name: Run Claude


### PR DESCRIPTION
## Summary

Reverts #158. GitHub reusable workflows do **not** allow `${{ secrets.* }}` in the `with:` block — this causes a "workflow file issue" startup failure. Secrets must go through the `secrets:` block.

Restores `pre_run_secret` which is exposed as `PRE_RUN_SECRET` env var during `pre_run` execution.

## Usage

```yaml
with:
  pre_run: "GITHUB_TOKEN=${PRE_RUN_SECRET} npm ci"
secrets:
  claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
  pre_run_secret: ${{ secrets.GH_PACKAGES_TOKEN }}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)