### PR TITLE
fix(workflows): add checkout step before local action references

### DIFF
--- a/.github/workflows/repo-claude-engineers.yml
+++ b/.github/workflows/repo-claude-engineers.yml
@@ -18,6 +18,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      - uses: actions/checkout@v4
       - uses: ./claude-respond
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}

--- a/.github/workflows/repo-claude-responder.yml
+++ b/.github/workflows/repo-claude-responder.yml
@@ -27,6 +27,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      - uses: actions/checkout@v4
       - uses: ./claude-respond
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}

--- a/.github/workflows/repo-engineer-managers.yml
+++ b/.github/workflows/repo-engineer-managers.yml
@@ -19,6 +19,7 @@ jobs:
       pull-requests: read
       id-token: write
     steps:
+      - uses: actions/checkout@v4
       - name: Run Documentation Engineer
         uses: ./claude-engineer
         with:
@@ -38,6 +39,7 @@ jobs:
       pull-requests: read
       id-token: write
     steps:
+      - uses: actions/checkout@v4
       - name: Run Code Janitor
         uses: ./claude-engineer
         with:
@@ -57,6 +59,7 @@ jobs:
       pull-requests: read
       id-token: write
     steps:
+      - uses: actions/checkout@v4
       - name: Run Security Engineer
         uses: ./claude-engineer
         with:

--- a/tests/test_repo_workflows.py
+++ b/tests/test_repo_workflows.py
@@ -54,6 +54,13 @@ class TestRepoClaudeResponder(unittest.TestCase):
         job = self.wf["jobs"]["respond"]
         self.assertIn("runs-on", job)
 
+    def test_has_checkout_before_action(self):
+        """Local ./ action references require the repo to be checked out first."""
+        job = self.wf["jobs"]["respond"]
+        steps = job.get("steps", [])
+        checkout_steps = [s for s in steps if "checkout" in s.get("uses", "")]
+        self.assertEqual(len(checkout_steps), 1)
+
     def test_no_secrets_block(self):
         """Composite action pattern doesn't need a secrets block."""
         for job_name, job in self.wf["jobs"].items():
@@ -94,6 +101,13 @@ class TestRepoClaudeEngineers(unittest.TestCase):
         if isinstance(triggers, dict):
             self.assertNotIn("workflow_run", triggers)
 
+    def test_has_checkout_before_action(self):
+        """Local ./ action references require the repo to be checked out first."""
+        job = self.wf["jobs"]["engineers"]
+        steps = job.get("steps", [])
+        checkout_steps = [s for s in steps if "checkout" in s.get("uses", "")]
+        self.assertEqual(len(checkout_steps), 1)
+
     def test_engineers_job_uses_claude_respond_action(self):
         job = self.wf["jobs"]["engineers"]
         steps = job.get("steps", [])
@@ -132,14 +146,14 @@ class TestRepoEngineerManagers(unittest.TestCase):
                 f"Job '{job_name}' should have exactly one claude-engineer step",
             )
 
-    def test_no_explicit_checkout_steps(self):
-        """claude-engineer handles checkout via claude-respond→claude-setup."""
+    def test_has_checkout_before_action(self):
+        """Each job must checkout the repo before using local ./claude-engineer action."""
         for job_name, job in self.wf["jobs"].items():
             steps = job.get("steps", [])
             checkout_steps = [s for s in steps if "checkout" in s.get("uses", "")]
             self.assertEqual(
-                len(checkout_steps), 0,
-                f"Job '{job_name}' has explicit checkout — claude-engineer handles this",
+                len(checkout_steps), 1,
+                f"Job '{job_name}' must have a checkout step for local action reference",
             )
 
     def test_each_job_has_unique_dashboard_label(self):


### PR DESCRIPTION
## Summary

All three internal workflows using local `./` action references were failing because GitHub Actions needs the repo checked out to find `action.yml` before it can run the action.

`claude-setup` handles checkout internally for **external consumers** (using remote refs like `@v0`), but for **local `./` references** in this repo's workflows, the repo must already be on disk.

- `repo-claude-responder.yml` — add `actions/checkout@v4` before `./claude-respond`
- `repo-claude-engineers.yml` — add `actions/checkout@v4` before `./claude-respond`
- `repo-engineer-managers.yml` — add `actions/checkout@v4` before `./claude-engineer` (3 jobs)
- Update workflow validation tests to assert checkout steps are present

## Test plan

- [x] All 347 unit tests pass
- [ ] Re-test all three workflows after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)