### PR TITLE
fix(workflows): add missing agent_name to responder workflow

### DIFF
--- a/.github/workflows/repo-claude-responder.yml
+++ b/.github/workflows/repo-claude-responder.yml
@@ -36,4 +36,5 @@ jobs:
           allowed_bots: "claude[bot]"
           notify_owners: "diranged"
           compose_prompt: "true"
+          agent_name: "auto"
           allowed_tools: "Bash(*),Read,Glob,Grep,Edit,Write,WebFetch,WebSearch"


### PR DESCRIPTION
## Summary

`repo-claude-responder.yml` sets `compose_prompt: "true"` but didn't pass `agent_name`, which `validate_inputs.sh` requires. The old shared workflow defaulted to `"auto"`.

## Test plan

- [ ] Re-test @claude mention after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)