### PR TITLE
fix(workflows): add allowed_bots to engineers workflow for auto-advance

### DIFF
--- a/.github/workflows/repo-claude-engineers.yml
+++ b/.github/workflows/repo-claude-engineers.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
           label_trigger: "claude"
+          allowed_bots: "claude[bot]"
           notify_owners: "diranged"
           compose_prompt: "true"
           allowed_tools: "Bash(*),Read,Glob,Grep,Edit,Write,WebFetch,WebSearch"


### PR DESCRIPTION
## Summary

The engineers workflow was rejecting label events from `claude[bot]` because `allowed_bots` wasn't set. This breaks the auto-advance pipeline — when the designer adds `claude:review`, the next stage rejects the event.

## Test plan

- [ ] Re-test auto-advance pipeline (claude:design → claude:review → claude:implement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)